### PR TITLE
feat: MCP server + live API upgrades (PubMed, ClinVar, gnomAD, ClinGen)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ back.code-workspace
 front.code-workspace
 BDD/clinvar.vcf
 dist
+coverage/

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,50 @@
+# PubMatcher MCP Server
+
+A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes PubMatcher's multi-database genomic analysis to any MCP-compatible AI client (Claude Desktop, VS Code Copilot, Cursor, etc.).
+
+The MCP server is a **thin layer** on top of the shared `utils/` — it imports the same data-fetching modules used by the web app, so improvements benefit both.
+
+## Tools
+
+| Tool | Description | Timeout |
+|------|-------------|---------|
+| `analyze_genes` | Full 8-database analysis for 1-10 genes | 120s |
+| `validate_gene` | Quick HGNC + ClinGen check | 10s |
+| `search_literature` | PubMed search with phenotype refinement | 15s |
+
+## Setup
+
+```bash
+cd mcp
+npm install
+```
+
+## Usage with Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "pubmatcher": {
+      "command": "node",
+      "args": ["/path/to/PubMatcher/mcp/server.js"]
+    }
+  }
+}
+```
+
+## Usage with VS Code
+
+Add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "pubmatcher": {
+      "command": "node",
+      "args": ["${workspaceFolder}/mcp/server.js"]
+    }
+  }
+}
+```

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "pubmatcher-mcp",
+  "version": "1.0.0",
+  "description": "MCP server for PubMatcher — exposes genomic analysis tools to AI assistants",
+  "private": true,
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "zod": "^3.24.2"
+  }
+}

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -4,191 +4,13 @@ import { z } from 'zod';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const { analyzeGenesStructured } = require('../services/dataservice.js');
-const fetchGeneCard = require('../utils/fetchGeneCard.js');
-const getPubMedData = require('../utils/getPubMedData.js');
+const { analyzeGenesStructured, validateGene, searchLiterature } = require('../services/dataservice.js');
+const { formatGeneAnalysis, formatValidation, formatLiterature } = require('../utils/formatters.js');
 
 const server = new McpServer({
     name: 'pubmatcher-mcp',
     version: '1.0.0',
 });
-
-// --- Output Formatters ---
-
-function formatSourceErrors(sourceErrors) {
-    if (!sourceErrors || sourceErrors.length === 0) return '';
-    const lines = ['\n### Data Source Warnings'];
-    for (const { source, error } of sourceErrors) {
-        lines.push(`- **${source}**: unavailable (${error})`);
-    }
-    lines.push('');
-    return lines.join('\n');
-}
-
-function formatGeneAnalysis(results) {
-    if (!results || results.length === 0) return 'No results returned.';
-
-    const sections = results.map((r) => {
-        if (!r.valid) {
-            return `## ${r.gene}\n**Error**: ${r.error}`;
-        }
-
-        const { geneInfo, sources, sourceErrors } = r;
-        const lines = [`## ${r.gene} — ${geneInfo.name || 'Unknown'}`];
-
-        // Source warnings at the top so the LLM sees them immediately
-        if (sourceErrors.length > 0) {
-            lines.push(formatSourceErrors(sourceErrors));
-        }
-
-        // Gene Info
-        lines.push('### Gene Information');
-        lines.push(`- **HGNC ID**: ${geneInfo.hgncId || 'N/A'}`);
-        lines.push(`- **Location**: ${geneInfo.location || 'N/A'}`);
-        lines.push(`- **Alias**: ${geneInfo.alias || 'N/A'}`);
-        lines.push(`- **OMIM ID**: ${geneInfo.omimId || 'N/A'}`);
-        lines.push(`- **Ensembl**: ${geneInfo.ensemblId || 'N/A'}`);
-        lines.push(`- **Gene Validity (ClinGen)**: ${geneInfo.geneValidity}`);
-        if (geneInfo.geneLink) lines.push(`- **GenCC**: ${geneInfo.geneLink}`);
-
-        // UniProt
-        const uniprot = sources.uniprot;
-        if (uniprot && !uniprot.error) {
-            lines.push('### UniProt Function');
-            lines.push(uniprot.geneFunction || 'No function data available.');
-            if (uniprot.bioProcessKeywords?.length > 0) {
-                lines.push(`**Biological processes**: ${uniprot.bioProcessKeywords.join(', ')}`);
-            }
-            if (uniprot.uniprotUrl) lines.push(`**UniProt entry**: ${uniprot.uniprotUrl}`);
-        }
-
-        // Constraints
-        const constraints = sources.constraints;
-        if (constraints && !constraints.error) {
-            lines.push('### gnomAD Constraint Scores');
-            const fmtC = (label, c) => {
-                if (!c || c.pLI === 'N/A') return `**${label}**: No data available`;
-                return `**${label}**: pLI=${c.pLI}, o/e LoF upper=${c.oe_lof_upper}, o/e mis upper=${c.oe_mis_upper}, mis_z=${c.mis_z}`;
-            };
-            lines.push(fmtC('gnomAD v4 (GRCh38)', constraints.constraints_v4));
-            lines.push(fmtC('gnomAD v2 (GRCh37)', constraints.constraints_v2));
-            if (constraints.constraintsDelta) {
-                lines.push('**Note**: Significant difference between v2 and v4 constraint scores.');
-            }
-            if (constraints.gnomadUrl) lines.push(`**gnomAD page**: ${constraints.gnomadUrl}`);
-        }
-
-        // ClinVar
-        const clinvar = sources.clinvar;
-        if (clinvar && !clinvar.error) {
-            lines.push('### ClinVar Variants');
-            lines.push(`- **Pathogenic LoF variants**: ${clinvar.lofVariants}`);
-            lines.push(`- **Pathogenic missense variants**: ${clinvar.missenseVariants}`);
-            lines.push(`- **VUS LoF**: ${clinvar.lofUnknown}`);
-            lines.push(`- **VUS missense**: ${clinvar.missenseUnknown}`);
-            lines.push(`- **Total pathogenic**: ${clinvar.totalPathogenic}`);
-            lines.push(`- **Total likely pathogenic**: ${clinvar.totalLikelyPathogenic}`);
-            if (clinvar.clinvarUrl) lines.push(`**ClinVar page**: ${clinvar.clinvarUrl}`);
-        }
-
-        // PubMed
-        const pubmed = sources.pubmed;
-        if (pubmed && !pubmed.error) {
-            lines.push('### PubMed Literature');
-            lines.push(`**Total articles**: ${pubmed.articleCount}`);
-            if (pubmed.articles?.length > 0) {
-                lines.push('**Top articles**:');
-                for (const a of pubmed.articles) {
-                    const authors = a.authors?.join(', ') || '';
-                    const citation = [a.journal, a.year].filter(Boolean).join(', ');
-                    lines.push(`- ${a.title}${authors ? ` — ${authors}` : ''}${citation ? ` (${citation})` : ''} [PMID: ${a.pmid}]`);
-                }
-            }
-            if (pubmed.pubmedUrl) lines.push(`**PubMed search**: ${pubmed.pubmedUrl}`);
-        }
-
-        // PanelApp
-        const panelApps = sources.panelApps;
-        if (panelApps && !panelApps.error) {
-            lines.push('### PanelApp Gene Panels');
-            lines.push(`- **Genomics England (UK)**: ${panelApps.panelAppEnglandCount ?? panelApps.panelAppEnglandError ?? 'N/A'} panels`);
-            lines.push(`- **PanelApp Australia**: ${panelApps.panelAppAustraliaCount ?? panelApps.panelAppAustraliaError ?? 'N/A'} panels`);
-        }
-
-        // Mouse KO
-        const mouseKO = sources.mouseKO;
-        if (mouseKO && !mouseKO.error && mouseKO.phenotypeCount > 0) {
-            lines.push('### IMPC Mouse Phenotypes');
-            lines.push(`**${mouseKO.phenotypeCount} phenotypes** across ${mouseKO.categoryCount} categories:`);
-            for (const [category, data] of Object.entries(mouseKO.mousePhenotypes)) {
-                const label = category.replace(/_/g, ' ');
-                const names = Array.isArray(data) ? data : data.names || [];
-                lines.push(`- **${label}**: ${names.join(', ')}`);
-            }
-            if (mouseKO.impcUrl) lines.push(`**IMPC page**: ${mouseKO.impcUrl}`);
-        }
-
-        // OMIM
-        const omim = sources.omim;
-        if (omim && !omim.error && omim.mim?.length > 0) {
-            lines.push('### OMIM Diseases');
-            for (const desc of omim.mim) {
-                lines.push(`- ${desc}`);
-            }
-        }
-
-        return lines.join('\n');
-    });
-
-    return sections.join('\n\n---\n\n');
-}
-
-function formatValidation(result) {
-    if (!result.valid) {
-        return `**${result.gene}**: Not found in HGNC. ${result.message}`;
-    }
-    const lines = [
-        `## ${result.gene} — Validated`,
-        `- **Full name**: ${result.name || 'N/A'}`,
-        `- **Alias**: ${result.alias || 'N/A'}`,
-        `- **Location**: ${result.location || 'N/A'}`,
-        `- **HGNC ID**: ${result.hgncId || 'N/A'}`,
-        `- **OMIM ID**: ${result.omimId || 'N/A'}`,
-        `- **Ensembl ID**: ${result.ensemblId || 'N/A'}`,
-        `- **Gene Validity (ClinGen)**: ${result.geneValidity || 'No Known'}`,
-    ];
-    if (result.maneSelect?.length > 0) {
-        lines.push(`- **MANE Select**: ${result.maneSelect.join(', ')}`);
-    }
-    if (result.geneLink) lines.push(`- **GenCC**: ${result.geneLink}`);
-    return lines.join('\n');
-}
-
-function formatLiterature(result) {
-    const lines = [`## PubMed results for ${result.gene}`];
-    lines.push(`**Total articles found**: ${result.articleCount}`);
-    if (result.error) {
-        lines.push(`\n**Warning**: PubMed query failed (${result.error}). Results may be incomplete.`);
-    }
-    if (result.articles?.length > 0) {
-        lines.push('');
-        for (const a of result.articles) {
-            const authors = a.authors?.join(', ') || '';
-            const citation = [a.journal, a.year].filter(Boolean).join(', ');
-            lines.push(`### ${a.title}`);
-            if (authors) lines.push(`**Authors**: ${authors}`);
-            if (citation) lines.push(`**Published in**: ${citation}`);
-            if (a.doi) lines.push(`**DOI**: ${a.doi}`);
-            lines.push(`**PMID**: ${a.pmid}`);
-            if (a.abstract) lines.push(`\n> ${a.abstract}`);
-            lines.push('');
-        }
-    }
-    if (result.pubmedUrl) lines.push(`**Full PubMed search**: ${result.pubmedUrl}`);
-    return lines.join('\n');
-}
-
-// --- Tool Definitions ---
 
 server.tool(
     'analyze_genes',
@@ -212,28 +34,8 @@ server.tool(
     },
     async ({ gene }) => {
         process.stderr.write(`[PubMatcher] validate_gene: ${gene}\n`);
-        const validatedGene = await fetchGeneCard(gene);
-        if (!validatedGene) {
-            return { content: [{ type: 'text', text: formatValidation({ valid: false, gene, message: `Gene symbol "${gene}" not found in HGNC` }) }] };
-        }
-        return {
-            content: [{
-                type: 'text',
-                text: formatValidation({
-                    valid: true,
-                    gene,
-                    name: validatedGene.geneName,
-                    alias: validatedGene.aliasName,
-                    location: validatedGene.location,
-                    hgncId: validatedGene.hgncId,
-                    omimId: validatedGene.omimId,
-                    ensemblId: validatedGene.ensemblGeneId,
-                    geneValidity: validatedGene.validityMarker,
-                    maneSelect: validatedGene.maneSelect,
-                    geneLink: validatedGene.hgncId ? `https://search.thegencc.org/genes/${validatedGene.hgncId}` : null,
-                }),
-            }],
-        };
+        const result = await validateGene(gene);
+        return { content: [{ type: 'text', text: formatValidation(result) }] };
     },
 );
 
@@ -246,12 +48,10 @@ server.tool(
     },
     async ({ gene, phenotypes }) => {
         process.stderr.write(`[PubMatcher] search_literature: ${gene}${phenotypes?.length ? ` | phenotypes: ${phenotypes.join(', ')}` : ''}\n`);
-        const result = await getPubMedData(gene, phenotypes || []);
+        const result = await searchLiterature(gene, phenotypes || []);
         return { content: [{ type: 'text', text: formatLiterature(result) }] };
     },
 );
-
-// --- Start Server ---
 
 async function main() {
     const transport = new StdioServerTransport();

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -3,190 +3,136 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import { createRequire } from 'node:module';
 
-// Bridge to import CJS utils from the parent project
 const require = createRequire(import.meta.url);
+const { analyzeGenesStructured } = require('../services/dataservice.js');
 const fetchGeneCard = require('../utils/fetchGeneCard.js');
 const getPubMedData = require('../utils/getPubMedData.js');
-const getUniProtFunction = require('../utils/getUniProtFunction.js');
-const getMouseKO = require('../utils/getMouseKO.js');
-const getGeneConstraints = require('../utils/getGeneConstraints.js');
-const getPanelApps = require('../utils/getPanelApps.js');
-const getClinVarData = require('../utils/getClinVarData.js');
-const fetchOmimData = require('../utils/fetchOMIM.js');
 
 const server = new McpServer({
     name: 'pubmatcher-mcp',
     version: '1.0.0',
 });
 
-// --- Core Data Functions ---
-
-async function analyzeGenes(genes, phenotypes = []) {
-    return Promise.all(
-        genes.map(async (gene) => {
-            try {
-                const validatedGene = await fetchGeneCard(gene);
-                if (!validatedGene) {
-                    return { gene, error: `Gene symbol "${gene}" not found in HGNC` };
-                }
-
-                const [pubmed, uniprot, mouseKO, constraints, panelApps, clinvar, omim] = await Promise.allSettled([
-                    getPubMedData(gene, phenotypes),
-                    getUniProtFunction(validatedGene.uniprotIds),
-                    getMouseKO(validatedGene.mgdId),
-                    getGeneConstraints(gene),
-                    getPanelApps(gene),
-                    getClinVarData(gene),
-                    fetchOmimData(validatedGene.ensemblGeneId),
-                ]);
-
-                const unwrap = (result, fallback) =>
-                    result.status === 'fulfilled' ? result.value : { ...fallback, error: result.reason?.message };
-
-                return {
-                    gene,
-                    geneInfo: {
-                        name: validatedGene.geneName,
-                        alias: validatedGene.aliasName,
-                        location: validatedGene.location,
-                        hgncId: validatedGene.hgncId,
-                        omimId: validatedGene.omimId,
-                        ensemblId: validatedGene.ensemblGeneId,
-                        geneValidity: validatedGene.validityMarker || 'No Known',
-                        geneLink: validatedGene.hgncId
-                            ? `https://search.thegencc.org/genes/${validatedGene.hgncId}`
-                            : null,
-                    },
-                    pubmed: unwrap(pubmed, { articles: [], articleCount: 0 }),
-                    uniprot: unwrap(uniprot, { geneFunction: null, bioProcessKeywords: [] }),
-                    mouseKO: unwrap(mouseKO, { mousePhenotypes: {}, phenotypeCount: 0 }),
-                    constraints: unwrap(constraints, { constraints_v2: {}, constraints_v4: {} }),
-                    panelApps: unwrap(panelApps, { panelAppEnglandCount: null, panelAppAustraliaCount: null }),
-                    clinvar: unwrap(clinvar, { lofVariants: 0, missenseVariants: 0 }),
-                    omim: unwrap(omim, { mim: [] }),
-                };
-            } catch (error) {
-                return { gene, error: error.message };
-            }
-        }),
-    );
-}
-
-async function validateGene(gene) {
-    const validatedGene = await fetchGeneCard(gene);
-    if (!validatedGene) {
-        return { valid: false, gene, message: `Gene symbol "${gene}" not found in HGNC` };
-    }
-    return {
-        valid: true,
-        gene,
-        name: validatedGene.geneName,
-        alias: validatedGene.aliasName,
-        location: validatedGene.location,
-        hgncId: validatedGene.hgncId,
-        omimId: validatedGene.omimId,
-        ensemblId: validatedGene.ensemblGeneId,
-        geneValidity: validatedGene.validityMarker,
-        maneSelect: validatedGene.maneSelect,
-        geneLink: validatedGene.hgncId
-            ? `https://search.thegencc.org/genes/${validatedGene.hgncId}`
-            : null,
-    };
-}
-
-async function searchLiterature(gene, phenotypes = []) {
-    return getPubMedData(gene, phenotypes);
-}
-
 // --- Output Formatters ---
+
+function formatSourceErrors(sourceErrors) {
+    if (!sourceErrors || sourceErrors.length === 0) return '';
+    const lines = ['\n### Data Source Warnings'];
+    for (const { source, error } of sourceErrors) {
+        lines.push(`- **${source}**: unavailable (${error})`);
+    }
+    lines.push('');
+    return lines.join('\n');
+}
 
 function formatGeneAnalysis(results) {
     if (!results || results.length === 0) return 'No results returned.';
 
     const sections = results.map((r) => {
-        if (r.error && !r.geneInfo) {
+        if (!r.valid) {
             return `## ${r.gene}\n**Error**: ${r.error}`;
         }
 
-        const lines = [`## ${r.gene} — ${r.geneInfo.name || 'Unknown'}`];
+        const { geneInfo, sources, sourceErrors } = r;
+        const lines = [`## ${r.gene} — ${geneInfo.name || 'Unknown'}`];
 
-        lines.push('### Gene Information');
-        lines.push(`- **HGNC ID**: ${r.geneInfo.hgncId || 'N/A'}`);
-        lines.push(`- **Location**: ${r.geneInfo.location || 'N/A'}`);
-        lines.push(`- **Alias**: ${r.geneInfo.alias || 'N/A'}`);
-        lines.push(`- **OMIM ID**: ${r.geneInfo.omimId || 'N/A'}`);
-        lines.push(`- **Ensembl**: ${r.geneInfo.ensemblId || 'N/A'}`);
-        lines.push(`- **Gene Validity (ClinGen)**: ${r.geneInfo.geneValidity}`);
-        if (r.geneInfo.geneLink) lines.push(`- **GenCC**: ${r.geneInfo.geneLink}`);
-
-        if (r.uniprot) {
-            lines.push('### UniProt Function');
-            lines.push(r.uniprot.geneFunction || 'No function data available.');
-            if (r.uniprot.bioProcessKeywords?.length > 0) {
-                lines.push(`**Biological processes**: ${r.uniprot.bioProcessKeywords.join(', ')}`);
-            }
-            if (r.uniprot.uniprotUrl) lines.push(`**UniProt entry**: ${r.uniprot.uniprotUrl}`);
+        // Source warnings at the top so the LLM sees them immediately
+        if (sourceErrors.length > 0) {
+            lines.push(formatSourceErrors(sourceErrors));
         }
 
-        if (r.constraints) {
+        // Gene Info
+        lines.push('### Gene Information');
+        lines.push(`- **HGNC ID**: ${geneInfo.hgncId || 'N/A'}`);
+        lines.push(`- **Location**: ${geneInfo.location || 'N/A'}`);
+        lines.push(`- **Alias**: ${geneInfo.alias || 'N/A'}`);
+        lines.push(`- **OMIM ID**: ${geneInfo.omimId || 'N/A'}`);
+        lines.push(`- **Ensembl**: ${geneInfo.ensemblId || 'N/A'}`);
+        lines.push(`- **Gene Validity (ClinGen)**: ${geneInfo.geneValidity}`);
+        if (geneInfo.geneLink) lines.push(`- **GenCC**: ${geneInfo.geneLink}`);
+
+        // UniProt
+        const uniprot = sources.uniprot;
+        if (uniprot && !uniprot.error) {
+            lines.push('### UniProt Function');
+            lines.push(uniprot.geneFunction || 'No function data available.');
+            if (uniprot.bioProcessKeywords?.length > 0) {
+                lines.push(`**Biological processes**: ${uniprot.bioProcessKeywords.join(', ')}`);
+            }
+            if (uniprot.uniprotUrl) lines.push(`**UniProt entry**: ${uniprot.uniprotUrl}`);
+        }
+
+        // Constraints
+        const constraints = sources.constraints;
+        if (constraints && !constraints.error) {
             lines.push('### gnomAD Constraint Scores');
             const fmtC = (label, c) => {
                 if (!c || c.pLI === 'N/A') return `**${label}**: No data available`;
                 return `**${label}**: pLI=${c.pLI}, o/e LoF upper=${c.oe_lof_upper}, o/e mis upper=${c.oe_mis_upper}, mis_z=${c.mis_z}`;
             };
-            lines.push(fmtC('gnomAD v4 (GRCh38)', r.constraints.constraints_v4));
-            lines.push(fmtC('gnomAD v2 (GRCh37)', r.constraints.constraints_v2));
-            if (r.constraints.constraintsDelta) {
+            lines.push(fmtC('gnomAD v4 (GRCh38)', constraints.constraints_v4));
+            lines.push(fmtC('gnomAD v2 (GRCh37)', constraints.constraints_v2));
+            if (constraints.constraintsDelta) {
                 lines.push('**Note**: Significant difference between v2 and v4 constraint scores.');
             }
-            if (r.constraints.gnomadUrl) lines.push(`**gnomAD page**: ${r.constraints.gnomadUrl}`);
+            if (constraints.gnomadUrl) lines.push(`**gnomAD page**: ${constraints.gnomadUrl}`);
         }
 
-        if (r.clinvar) {
+        // ClinVar
+        const clinvar = sources.clinvar;
+        if (clinvar && !clinvar.error) {
             lines.push('### ClinVar Variants');
-            lines.push(`- **Pathogenic LoF variants**: ${r.clinvar.lofVariants}`);
-            lines.push(`- **Pathogenic missense variants**: ${r.clinvar.missenseVariants}`);
-            lines.push(`- **VUS LoF**: ${r.clinvar.lofUnknown}`);
-            lines.push(`- **VUS missense**: ${r.clinvar.missenseUnknown}`);
-            lines.push(`- **Total pathogenic**: ${r.clinvar.totalPathogenic}`);
-            lines.push(`- **Total likely pathogenic**: ${r.clinvar.totalLikelyPathogenic}`);
-            if (r.clinvar.clinvarUrl) lines.push(`**ClinVar page**: ${r.clinvar.clinvarUrl}`);
+            lines.push(`- **Pathogenic LoF variants**: ${clinvar.lofVariants}`);
+            lines.push(`- **Pathogenic missense variants**: ${clinvar.missenseVariants}`);
+            lines.push(`- **VUS LoF**: ${clinvar.lofUnknown}`);
+            lines.push(`- **VUS missense**: ${clinvar.missenseUnknown}`);
+            lines.push(`- **Total pathogenic**: ${clinvar.totalPathogenic}`);
+            lines.push(`- **Total likely pathogenic**: ${clinvar.totalLikelyPathogenic}`);
+            if (clinvar.clinvarUrl) lines.push(`**ClinVar page**: ${clinvar.clinvarUrl}`);
         }
 
-        if (r.pubmed) {
+        // PubMed
+        const pubmed = sources.pubmed;
+        if (pubmed && !pubmed.error) {
             lines.push('### PubMed Literature');
-            lines.push(`**Total articles**: ${r.pubmed.articleCount}`);
-            if (r.pubmed.articles?.length > 0) {
+            lines.push(`**Total articles**: ${pubmed.articleCount}`);
+            if (pubmed.articles?.length > 0) {
                 lines.push('**Top articles**:');
-                for (const a of r.pubmed.articles) {
+                for (const a of pubmed.articles) {
                     const authors = a.authors?.join(', ') || '';
                     const citation = [a.journal, a.year].filter(Boolean).join(', ');
                     lines.push(`- ${a.title}${authors ? ` — ${authors}` : ''}${citation ? ` (${citation})` : ''} [PMID: ${a.pmid}]`);
                 }
             }
-            if (r.pubmed.pubmedUrl) lines.push(`**PubMed search**: ${r.pubmed.pubmedUrl}`);
+            if (pubmed.pubmedUrl) lines.push(`**PubMed search**: ${pubmed.pubmedUrl}`);
         }
 
-        if (r.panelApps) {
+        // PanelApp
+        const panelApps = sources.panelApps;
+        if (panelApps && !panelApps.error) {
             lines.push('### PanelApp Gene Panels');
-            lines.push(`- **Genomics England (UK)**: ${r.panelApps.panelAppEnglandCount ?? r.panelApps.panelAppEnglandError ?? 'N/A'} panels`);
-            lines.push(`- **PanelApp Australia**: ${r.panelApps.panelAppAustraliaCount ?? r.panelApps.panelAppAustraliaError ?? 'N/A'} panels`);
+            lines.push(`- **Genomics England (UK)**: ${panelApps.panelAppEnglandCount ?? panelApps.panelAppEnglandError ?? 'N/A'} panels`);
+            lines.push(`- **PanelApp Australia**: ${panelApps.panelAppAustraliaCount ?? panelApps.panelAppAustraliaError ?? 'N/A'} panels`);
         }
 
-        if (r.mouseKO && r.mouseKO.phenotypeCount > 0) {
+        // Mouse KO
+        const mouseKO = sources.mouseKO;
+        if (mouseKO && !mouseKO.error && mouseKO.phenotypeCount > 0) {
             lines.push('### IMPC Mouse Phenotypes');
-            lines.push(`**${r.mouseKO.phenotypeCount} phenotypes** across ${r.mouseKO.categoryCount} categories:`);
-            for (const [category, data] of Object.entries(r.mouseKO.mousePhenotypes)) {
+            lines.push(`**${mouseKO.phenotypeCount} phenotypes** across ${mouseKO.categoryCount} categories:`);
+            for (const [category, data] of Object.entries(mouseKO.mousePhenotypes)) {
                 const label = category.replace(/_/g, ' ');
                 const names = Array.isArray(data) ? data : data.names || [];
                 lines.push(`- **${label}**: ${names.join(', ')}`);
             }
-            if (r.mouseKO.impcUrl) lines.push(`**IMPC page**: ${r.mouseKO.impcUrl}`);
+            if (mouseKO.impcUrl) lines.push(`**IMPC page**: ${mouseKO.impcUrl}`);
         }
 
-        if (r.omim?.mim?.length > 0) {
+        // OMIM
+        const omim = sources.omim;
+        if (omim && !omim.error && omim.mim?.length > 0) {
             lines.push('### OMIM Diseases');
-            for (const desc of r.omim.mim) {
+            for (const desc of omim.mim) {
                 lines.push(`- ${desc}`);
             }
         }
@@ -221,6 +167,9 @@ function formatValidation(result) {
 function formatLiterature(result) {
     const lines = [`## PubMed results for ${result.gene}`];
     lines.push(`**Total articles found**: ${result.articleCount}`);
+    if (result.error) {
+        lines.push(`\n**Warning**: PubMed query failed (${result.error}). Results may be incomplete.`);
+    }
     if (result.articles?.length > 0) {
         lines.push('');
         for (const a of result.articles) {
@@ -250,7 +199,7 @@ server.tool(
     },
     async ({ genes, phenotypes }) => {
         process.stderr.write(`[PubMatcher] analyze_genes: ${genes.join(', ')}${phenotypes?.length ? ` | phenotypes: ${phenotypes.join(', ')}` : ''}\n`);
-        const results = await analyzeGenes(genes, phenotypes || []);
+        const results = await analyzeGenesStructured(genes, phenotypes || []);
         return { content: [{ type: 'text', text: formatGeneAnalysis(results) }] };
     },
 );
@@ -263,8 +212,28 @@ server.tool(
     },
     async ({ gene }) => {
         process.stderr.write(`[PubMatcher] validate_gene: ${gene}\n`);
-        const result = await validateGene(gene);
-        return { content: [{ type: 'text', text: formatValidation(result) }] };
+        const validatedGene = await fetchGeneCard(gene);
+        if (!validatedGene) {
+            return { content: [{ type: 'text', text: formatValidation({ valid: false, gene, message: `Gene symbol "${gene}" not found in HGNC` }) }] };
+        }
+        return {
+            content: [{
+                type: 'text',
+                text: formatValidation({
+                    valid: true,
+                    gene,
+                    name: validatedGene.geneName,
+                    alias: validatedGene.aliasName,
+                    location: validatedGene.location,
+                    hgncId: validatedGene.hgncId,
+                    omimId: validatedGene.omimId,
+                    ensemblId: validatedGene.ensemblGeneId,
+                    geneValidity: validatedGene.validityMarker,
+                    maneSelect: validatedGene.maneSelect,
+                    geneLink: validatedGene.hgncId ? `https://search.thegencc.org/genes/${validatedGene.hgncId}` : null,
+                }),
+            }],
+        };
     },
 );
 
@@ -277,7 +246,7 @@ server.tool(
     },
     async ({ gene, phenotypes }) => {
         process.stderr.write(`[PubMatcher] search_literature: ${gene}${phenotypes?.length ? ` | phenotypes: ${phenotypes.join(', ')}` : ''}\n`);
-        const result = await searchLiterature(gene, phenotypes || []);
+        const result = await getPubMedData(gene, phenotypes || []);
         return { content: [{ type: 'text', text: formatLiterature(result) }] };
     },
 );

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -1,0 +1,296 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import { createRequire } from 'node:module';
+
+// Bridge to import CJS utils from the parent project
+const require = createRequire(import.meta.url);
+const fetchGeneCard = require('../utils/fetchGeneCard.js');
+const getPubMedData = require('../utils/getPubMedData.js');
+const getUniProtFunction = require('../utils/getUniProtFunction.js');
+const getMouseKO = require('../utils/getMouseKO.js');
+const getGeneConstraints = require('../utils/getGeneConstraints.js');
+const getPanelApps = require('../utils/getPanelApps.js');
+const getClinVarData = require('../utils/getClinVarData.js');
+const fetchOmimData = require('../utils/fetchOMIM.js');
+
+const server = new McpServer({
+    name: 'pubmatcher-mcp',
+    version: '1.0.0',
+});
+
+// --- Core Data Functions ---
+
+async function analyzeGenes(genes, phenotypes = []) {
+    return Promise.all(
+        genes.map(async (gene) => {
+            try {
+                const validatedGene = await fetchGeneCard(gene);
+                if (!validatedGene) {
+                    return { gene, error: `Gene symbol "${gene}" not found in HGNC` };
+                }
+
+                const [pubmed, uniprot, mouseKO, constraints, panelApps, clinvar, omim] = await Promise.allSettled([
+                    getPubMedData(gene, phenotypes),
+                    getUniProtFunction(validatedGene.uniprotIds),
+                    getMouseKO(validatedGene.mgdId),
+                    getGeneConstraints(gene),
+                    getPanelApps(gene),
+                    getClinVarData(gene),
+                    fetchOmimData(validatedGene.ensemblGeneId),
+                ]);
+
+                const unwrap = (result, fallback) =>
+                    result.status === 'fulfilled' ? result.value : { ...fallback, error: result.reason?.message };
+
+                return {
+                    gene,
+                    geneInfo: {
+                        name: validatedGene.geneName,
+                        alias: validatedGene.aliasName,
+                        location: validatedGene.location,
+                        hgncId: validatedGene.hgncId,
+                        omimId: validatedGene.omimId,
+                        ensemblId: validatedGene.ensemblGeneId,
+                        geneValidity: validatedGene.validityMarker || 'No Known',
+                        geneLink: validatedGene.hgncId
+                            ? `https://search.thegencc.org/genes/${validatedGene.hgncId}`
+                            : null,
+                    },
+                    pubmed: unwrap(pubmed, { articles: [], articleCount: 0 }),
+                    uniprot: unwrap(uniprot, { geneFunction: null, bioProcessKeywords: [] }),
+                    mouseKO: unwrap(mouseKO, { mousePhenotypes: {}, phenotypeCount: 0 }),
+                    constraints: unwrap(constraints, { constraints_v2: {}, constraints_v4: {} }),
+                    panelApps: unwrap(panelApps, { panelAppEnglandCount: null, panelAppAustraliaCount: null }),
+                    clinvar: unwrap(clinvar, { lofVariants: 0, missenseVariants: 0 }),
+                    omim: unwrap(omim, { mim: [] }),
+                };
+            } catch (error) {
+                return { gene, error: error.message };
+            }
+        }),
+    );
+}
+
+async function validateGene(gene) {
+    const validatedGene = await fetchGeneCard(gene);
+    if (!validatedGene) {
+        return { valid: false, gene, message: `Gene symbol "${gene}" not found in HGNC` };
+    }
+    return {
+        valid: true,
+        gene,
+        name: validatedGene.geneName,
+        alias: validatedGene.aliasName,
+        location: validatedGene.location,
+        hgncId: validatedGene.hgncId,
+        omimId: validatedGene.omimId,
+        ensemblId: validatedGene.ensemblGeneId,
+        geneValidity: validatedGene.validityMarker,
+        maneSelect: validatedGene.maneSelect,
+        geneLink: validatedGene.hgncId
+            ? `https://search.thegencc.org/genes/${validatedGene.hgncId}`
+            : null,
+    };
+}
+
+async function searchLiterature(gene, phenotypes = []) {
+    return getPubMedData(gene, phenotypes);
+}
+
+// --- Output Formatters ---
+
+function formatGeneAnalysis(results) {
+    if (!results || results.length === 0) return 'No results returned.';
+
+    const sections = results.map((r) => {
+        if (r.error && !r.geneInfo) {
+            return `## ${r.gene}\n**Error**: ${r.error}`;
+        }
+
+        const lines = [`## ${r.gene} — ${r.geneInfo.name || 'Unknown'}`];
+
+        lines.push('### Gene Information');
+        lines.push(`- **HGNC ID**: ${r.geneInfo.hgncId || 'N/A'}`);
+        lines.push(`- **Location**: ${r.geneInfo.location || 'N/A'}`);
+        lines.push(`- **Alias**: ${r.geneInfo.alias || 'N/A'}`);
+        lines.push(`- **OMIM ID**: ${r.geneInfo.omimId || 'N/A'}`);
+        lines.push(`- **Ensembl**: ${r.geneInfo.ensemblId || 'N/A'}`);
+        lines.push(`- **Gene Validity (ClinGen)**: ${r.geneInfo.geneValidity}`);
+        if (r.geneInfo.geneLink) lines.push(`- **GenCC**: ${r.geneInfo.geneLink}`);
+
+        if (r.uniprot) {
+            lines.push('### UniProt Function');
+            lines.push(r.uniprot.geneFunction || 'No function data available.');
+            if (r.uniprot.bioProcessKeywords?.length > 0) {
+                lines.push(`**Biological processes**: ${r.uniprot.bioProcessKeywords.join(', ')}`);
+            }
+            if (r.uniprot.uniprotUrl) lines.push(`**UniProt entry**: ${r.uniprot.uniprotUrl}`);
+        }
+
+        if (r.constraints) {
+            lines.push('### gnomAD Constraint Scores');
+            const fmtC = (label, c) => {
+                if (!c || c.pLI === 'N/A') return `**${label}**: No data available`;
+                return `**${label}**: pLI=${c.pLI}, o/e LoF upper=${c.oe_lof_upper}, o/e mis upper=${c.oe_mis_upper}, mis_z=${c.mis_z}`;
+            };
+            lines.push(fmtC('gnomAD v4 (GRCh38)', r.constraints.constraints_v4));
+            lines.push(fmtC('gnomAD v2 (GRCh37)', r.constraints.constraints_v2));
+            if (r.constraints.constraintsDelta) {
+                lines.push('**Note**: Significant difference between v2 and v4 constraint scores.');
+            }
+            if (r.constraints.gnomadUrl) lines.push(`**gnomAD page**: ${r.constraints.gnomadUrl}`);
+        }
+
+        if (r.clinvar) {
+            lines.push('### ClinVar Variants');
+            lines.push(`- **Pathogenic LoF variants**: ${r.clinvar.lofVariants}`);
+            lines.push(`- **Pathogenic missense variants**: ${r.clinvar.missenseVariants}`);
+            lines.push(`- **VUS LoF**: ${r.clinvar.lofUnknown}`);
+            lines.push(`- **VUS missense**: ${r.clinvar.missenseUnknown}`);
+            lines.push(`- **Total pathogenic**: ${r.clinvar.totalPathogenic}`);
+            lines.push(`- **Total likely pathogenic**: ${r.clinvar.totalLikelyPathogenic}`);
+            if (r.clinvar.clinvarUrl) lines.push(`**ClinVar page**: ${r.clinvar.clinvarUrl}`);
+        }
+
+        if (r.pubmed) {
+            lines.push('### PubMed Literature');
+            lines.push(`**Total articles**: ${r.pubmed.articleCount}`);
+            if (r.pubmed.articles?.length > 0) {
+                lines.push('**Top articles**:');
+                for (const a of r.pubmed.articles) {
+                    const authors = a.authors?.join(', ') || '';
+                    const citation = [a.journal, a.year].filter(Boolean).join(', ');
+                    lines.push(`- ${a.title}${authors ? ` — ${authors}` : ''}${citation ? ` (${citation})` : ''} [PMID: ${a.pmid}]`);
+                }
+            }
+            if (r.pubmed.pubmedUrl) lines.push(`**PubMed search**: ${r.pubmed.pubmedUrl}`);
+        }
+
+        if (r.panelApps) {
+            lines.push('### PanelApp Gene Panels');
+            lines.push(`- **Genomics England (UK)**: ${r.panelApps.panelAppEnglandCount ?? r.panelApps.panelAppEnglandError ?? 'N/A'} panels`);
+            lines.push(`- **PanelApp Australia**: ${r.panelApps.panelAppAustraliaCount ?? r.panelApps.panelAppAustraliaError ?? 'N/A'} panels`);
+        }
+
+        if (r.mouseKO && r.mouseKO.phenotypeCount > 0) {
+            lines.push('### IMPC Mouse Phenotypes');
+            lines.push(`**${r.mouseKO.phenotypeCount} phenotypes** across ${r.mouseKO.categoryCount} categories:`);
+            for (const [category, data] of Object.entries(r.mouseKO.mousePhenotypes)) {
+                const label = category.replace(/_/g, ' ');
+                const names = Array.isArray(data) ? data : data.names || [];
+                lines.push(`- **${label}**: ${names.join(', ')}`);
+            }
+            if (r.mouseKO.impcUrl) lines.push(`**IMPC page**: ${r.mouseKO.impcUrl}`);
+        }
+
+        if (r.omim?.mim?.length > 0) {
+            lines.push('### OMIM Diseases');
+            for (const desc of r.omim.mim) {
+                lines.push(`- ${desc}`);
+            }
+        }
+
+        return lines.join('\n');
+    });
+
+    return sections.join('\n\n---\n\n');
+}
+
+function formatValidation(result) {
+    if (!result.valid) {
+        return `**${result.gene}**: Not found in HGNC. ${result.message}`;
+    }
+    const lines = [
+        `## ${result.gene} — Validated`,
+        `- **Full name**: ${result.name || 'N/A'}`,
+        `- **Alias**: ${result.alias || 'N/A'}`,
+        `- **Location**: ${result.location || 'N/A'}`,
+        `- **HGNC ID**: ${result.hgncId || 'N/A'}`,
+        `- **OMIM ID**: ${result.omimId || 'N/A'}`,
+        `- **Ensembl ID**: ${result.ensemblId || 'N/A'}`,
+        `- **Gene Validity (ClinGen)**: ${result.geneValidity || 'No Known'}`,
+    ];
+    if (result.maneSelect?.length > 0) {
+        lines.push(`- **MANE Select**: ${result.maneSelect.join(', ')}`);
+    }
+    if (result.geneLink) lines.push(`- **GenCC**: ${result.geneLink}`);
+    return lines.join('\n');
+}
+
+function formatLiterature(result) {
+    const lines = [`## PubMed results for ${result.gene}`];
+    lines.push(`**Total articles found**: ${result.articleCount}`);
+    if (result.articles?.length > 0) {
+        lines.push('');
+        for (const a of result.articles) {
+            const authors = a.authors?.join(', ') || '';
+            const citation = [a.journal, a.year].filter(Boolean).join(', ');
+            lines.push(`### ${a.title}`);
+            if (authors) lines.push(`**Authors**: ${authors}`);
+            if (citation) lines.push(`**Published in**: ${citation}`);
+            if (a.doi) lines.push(`**DOI**: ${a.doi}`);
+            lines.push(`**PMID**: ${a.pmid}`);
+            if (a.abstract) lines.push(`\n> ${a.abstract}`);
+            lines.push('');
+        }
+    }
+    if (result.pubmedUrl) lines.push(`**Full PubMed search**: ${result.pubmedUrl}`);
+    return lines.join('\n');
+}
+
+// --- Tool Definitions ---
+
+server.tool(
+    'analyze_genes',
+    'Perform comprehensive multi-database genomic analysis. Queries 8 databases in parallel for each gene: HGNC validation, PubMed literature, ClinVar variants, gnomAD constraints, UniProt function, IMPC mouse phenotypes, PanelApp panels, and OMIM diseases.',
+    {
+        genes: z.array(z.string()).min(1).max(10).describe('Gene symbols to analyze (e.g. ["BRCA1", "TP53"]). Maximum 10 genes per request.'),
+        phenotypes: z.array(z.string()).optional().describe('Phenotype terms to refine PubMed literature search (e.g. ["breast cancer", "ovarian cancer"])'),
+    },
+    async ({ genes, phenotypes }) => {
+        process.stderr.write(`[PubMatcher] analyze_genes: ${genes.join(', ')}${phenotypes?.length ? ` | phenotypes: ${phenotypes.join(', ')}` : ''}\n`);
+        const results = await analyzeGenes(genes, phenotypes || []);
+        return { content: [{ type: 'text', text: formatGeneAnalysis(results) }] };
+    },
+);
+
+server.tool(
+    'validate_gene',
+    'Validate a gene symbol against HGNC and check ClinGen gene-disease validity classification. Quick lightweight check before committing to a full analysis.',
+    {
+        gene: z.string().describe('Gene symbol to validate (e.g. "BRCA1")'),
+    },
+    async ({ gene }) => {
+        process.stderr.write(`[PubMatcher] validate_gene: ${gene}\n`);
+        const result = await validateGene(gene);
+        return { content: [{ type: 'text', text: formatValidation(result) }] };
+    },
+);
+
+server.tool(
+    'search_literature',
+    'Search PubMed for literature about a gene, optionally refined by phenotype terms. Returns article count, top 5 articles with titles, authors, abstracts, and DOIs.',
+    {
+        gene: z.string().describe('Gene symbol to search (e.g. "TP53")'),
+        phenotypes: z.array(z.string()).optional().describe('Phenotype terms to refine the search (e.g. ["cancer", "Li-Fraumeni syndrome"])'),
+    },
+    async ({ gene, phenotypes }) => {
+        process.stderr.write(`[PubMatcher] search_literature: ${gene}${phenotypes?.length ? ` | phenotypes: ${phenotypes.join(', ')}` : ''}\n`);
+        const result = await searchLiterature(gene, phenotypes || []);
+        return { content: [{ type: 'text', text: formatLiterature(result) }] };
+    },
+);
+
+// --- Start Server ---
+
+async function main() {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    process.stderr.write('[PubMatcher] PubMatcher Genomics MCP server started\n');
+}
+
+main().catch((error) => {
+    process.stderr.write(`[PubMatcher] Fatal error: ${error.message}\n`);
+    process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
       "devDependencies": {
         "@vue/cli-service": "^5.0.8",
         "cross-env": "^7.0.3",
+        "jest": "^30.3.0",
         "prettier": "^3.4.1",
         "prettier-plugin-tailwindcss": "^0.6.9"
       }
@@ -85,39 +86,126 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz",
-      "integrity": "sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
-      "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.25.9",
-        "@babel/helper-validator-option": "^7.25.9",
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/core/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -126,41 +214,107 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/parser": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
-      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.0"
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -169,18 +323,323 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/types": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -190,6 +649,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -382,33 +875,528 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "license": "MIT",
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.24"
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz",
+      "integrity": "sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz",
+      "integrity": "sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/reporters": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-changed-files": "30.3.0",
+        "jest-config": "30.3.0",
+        "jest-haste-map": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-resolve-dependencies": "30.3.0",
+        "jest-runner": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "jest-watcher": "30.3.0",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@jest/core/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+      "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "30.3.0",
+        "jest-snapshot": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+      "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@sinonjs/fake-timers": "^15.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
+      "integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/expect": "30.3.0",
+        "@jest/types": "30.3.0",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz",
+      "integrity": "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "collect-v8-coverage": "^1.0.2",
+        "exit-x": "^0.2.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^5.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-worker": "30.3.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.2",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/jest-worker": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+      "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.3.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
+      "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+      "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "callsites": "^3.1.0",
+        "graceful-fs": "^4.2.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz",
+      "integrity": "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "collect-v8-coverage": "^1.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz",
+      "integrity": "sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.3.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
+      "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.3.0",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.3.0",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -432,9 +1420,9 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -495,6 +1483,19 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
     "node_modules/@node-ipc/js-queue": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@node-ipc/js-queue/-/js-queue-2.0.3.tgz",
@@ -551,6 +1552,19 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@polka/url": {
@@ -661,6 +1675,33 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.48",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+      "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
+      "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
     "node_modules/@soda/friendly-errors-webpack-plugin": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@soda/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.8.1.tgz",
@@ -709,6 +1750,62 @@
       "license": "ISC",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
       }
     },
     "node_modules/@types/body-parser": {
@@ -844,6 +1941,33 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -969,6 +2093,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
@@ -999,6 +2130,299 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@vue/cli-overlay": {
       "version": "5.0.8",
@@ -1036,6 +2460,7 @@
       "integrity": "sha512-nV7tYQLe7YsTtzFrfOMIHc5N2hp5lHG2rpYr0aNja9rNljdgcPZLyQRb2YRivTHqTv7lI962UXFURcpStHgyFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.12.16",
         "@soda/friendly-errors-webpack-plugin": "^1.8.0",
@@ -1847,6 +3272,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2043,6 +3469,16 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -2119,6 +3555,105 @@
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.14.4"
+      }
+    },
+    "node_modules/babel-jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
+      "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "30.3.0",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.3.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "workspaces": [
+        "test/babel-8"
+      ],
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
+      "integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/babel__core": "^7.20.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
+      "integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "30.3.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
       }
     },
     "node_modules/balanced-match": {
@@ -2322,6 +3857,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -2333,6 +3869,16 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
       }
     },
     "node_modules/bson": {
@@ -2520,11 +4066,22 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chart.js": {
       "version": "4.4.7",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.7.tgz",
       "integrity": "sha512-pwkcKfdzTMAU/+jNosKhNL2bHtJc/sSmYgVbuGTEDhzkrhmyihmP7vUc/5ZK9WopidMDHNe3Wm7jOd/WhuHWuw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -2672,6 +4229,29 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/clean-css": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
@@ -2808,6 +4388,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
     "node_modules/codepage": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
@@ -2816,6 +4407,13 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2982,6 +4580,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
@@ -3143,6 +4748,7 @@
       "integrity": "sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "icss-utils": "^5.1.0",
         "postcss": "^8.4.33",
@@ -3231,6 +4837,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3477,6 +5084,21 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/deep-equal": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
@@ -3670,6 +5292,16 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3879,6 +5511,19 @@
       "integrity": "sha512-t8c+zLmJHa9dJy96yBZRXGQYoiCEnHYgFwn1asvSPZSUdVxnB62A4RASd7k41ytG3ErFBA0TpHlKg9D9SQBmLg==",
       "license": "ISC"
     },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -4038,6 +5683,20 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/esrecurse": {
@@ -4207,6 +5866,34 @@
         "which": "bin/which"
       }
     },
+    "node_modules/exit-x": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+      "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "4.21.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
@@ -4318,6 +6005,16 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
       }
     },
     "node_modules/figures": {
@@ -4644,6 +6341,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -4671,6 +6378,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/get-stream": {
@@ -5224,6 +6941,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -5357,6 +7104,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/is-glob": {
@@ -5508,6 +7265,144 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -5547,6 +7442,991 @@
       "integrity": "sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
+      "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.3.0",
+        "@jest/types": "30.3.0",
+        "import-local": "^3.2.0",
+        "jest-cli": "30.3.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz",
+      "integrity": "sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "jest-util": "30.3.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz",
+      "integrity": "sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/expect": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "co": "^4.6.0",
+        "dedent": "^1.6.0",
+        "is-generator-fn": "^2.1.0",
+        "jest-each": "30.3.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "30.3.0",
+        "pure-rand": "^7.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz",
+      "integrity": "sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "exit-x": "^0.2.2",
+        "import-local": "^3.2.0",
+        "jest-config": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-cli/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-cli/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-cli/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz",
+      "integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/get-type": "30.1.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/test-sequencer": "30.3.0",
+        "@jest/types": "30.3.0",
+        "babel-jest": "30.3.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "deepmerge": "^4.3.1",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-circus": "30.3.0",
+        "jest-docblock": "30.2.0",
+        "jest-environment-node": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-runner": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "parse-json": "^5.2.0",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "esbuild-register": ">=3.4.0",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "esbuild-register": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
+      "integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz",
+      "integrity": "sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "jest-util": "30.3.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
+      "integrity": "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
+      "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.3.0",
+        "jest-worker": "30.3.0",
+        "picomatch": "^4.0.3",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/jest-worker": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+      "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.3.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
+      "integrity": "sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.3.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz",
+      "integrity": "sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-pnp-resolver": "^1.2.3",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "slash": "^3.0.0",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz",
+      "integrity": "sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "30.0.1",
+        "jest-snapshot": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz",
+      "integrity": "sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/environment": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-docblock": "30.2.0",
+        "jest-environment-node": "30.3.0",
+        "jest-haste-map": "30.3.0",
+        "jest-leak-detector": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-resolve": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-watcher": "30.3.0",
+        "jest-worker": "30.3.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/jest-worker": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+      "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.3.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz",
+      "integrity": "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/globals": "30.3.0",
+        "@jest/source-map": "30.0.1",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "cjs-module-lexer": "^2.1.0",
+        "collect-v8-coverage": "^1.0.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
+      "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.3.0",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.3.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "pretty-format": "30.3.0",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz",
+      "integrity": "sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.3.0",
+        "camelcase": "^6.3.0",
+        "chalk": "^4.1.2",
+        "leven": "^3.1.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz",
+      "integrity": "sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "jest-util": "30.3.0",
+        "string-length": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -5624,6 +8504,33 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
@@ -5781,6 +8688,16 @@
       "license": "MIT",
       "dependencies": {
         "launch-editor": "^2.9.1"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lilconfig": {
@@ -6100,6 +9017,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
@@ -6262,6 +9189,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6609,6 +9537,29 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -6700,6 +9651,13 @@
       "engines": {
         "node": ">= 6.13.0"
       }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.18",
@@ -7286,6 +10244,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.13.1.tgz",
       "integrity": "sha512-OUir1A0rPNZlX//c7ksiu7crsGZTKSOXJPgtNiHGIlC9H0lO+NC6ZDYksSgBYY/thSWhnSRBv8w1lieNNGATNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.7.0",
         "pg-pool": "^3.7.0",
@@ -7428,12 +10387,25 @@
       }
     },
     "node_modules/pirates": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
-      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/png-js": {
@@ -7502,6 +10474,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -8254,6 +11227,7 @@
       "integrity": "sha512-G+YdqtITVZmOJje6QkXQWzl3fSfMxFwm1tjTyo9exhkmWSqC4Yhd1+lug++IlR2mvRVAxEDDWYkQdeSztajqgg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8352,6 +11326,34 @@
       "dependencies": {
         "lodash": "^4.17.20",
         "renderkid": "^3.0.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/process": {
@@ -8495,6 +11497,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
@@ -8575,6 +11594,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -8839,6 +11865,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-cwd/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/resolve-from": {
@@ -9515,6 +12564,13 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ssf": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
@@ -9548,6 +12604,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -9578,6 +12657,20 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -9633,6 +12726,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -9651,6 +12754,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stylehacks": {
@@ -9895,6 +13011,22 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.9"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.15",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.15.tgz",
@@ -10047,6 +13179,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -10133,6 +13280,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -10188,6 +13342,16 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/type-fest": {
       "version": "0.6.0",
@@ -10282,6 +13446,41 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
@@ -10369,6 +13568,21 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -10413,6 +13627,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
       "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.13",
         "@vue/compiler-sfc": "3.5.13",
@@ -10611,6 +13826,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
@@ -10660,6 +13885,7 @@
       "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -10796,6 +14022,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10913,6 +14140,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11185,6 +14413,33 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -11320,6 +14575,19 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -53,12 +53,14 @@
   "devDependencies": {
     "@vue/cli-service": "^5.0.8",
     "cross-env": "^7.0.3",
+    "jest": "^30.3.0",
     "prettier": "^3.4.1",
     "prettier-plugin-tailwindcss": "^0.6.9"
   },
   "scripts": {
     "dev": "vue-cli-service serve",
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build"
+    "build": "vue-cli-service build",
+    "test": "jest --verbose"
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "dev": "vue-cli-service serve",
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "test": "jest --verbose"
+    "test": "jest --verbose --testPathIgnorePatterns=integration",
+    "test:integration": "jest --verbose --testPathPatterns=integration --testTimeout=180000"
   }
 }

--- a/services/dataservice.js
+++ b/services/dataservice.js
@@ -142,6 +142,40 @@ async function getData(req) {
   return analyzeGenes(genes, phenotypes)
 }
 
+/**
+ * Validate a single gene symbol against HGNC + ClinGen.
+ */
+async function validateGene(gene) {
+  const validatedGene = await fetchGeneCard(gene)
+  if (!validatedGene) {
+    return { valid: false, gene, message: `Gene symbol "${gene}" not found in HGNC` }
+  }
+  return {
+    valid: true,
+    gene,
+    name: validatedGene.geneName,
+    alias: validatedGene.aliasName,
+    location: validatedGene.location,
+    hgncId: validatedGene.hgncId,
+    omimId: validatedGene.omimId,
+    ensemblId: validatedGene.ensemblGeneId,
+    geneValidity: validatedGene.validityMarker,
+    maneSelect: validatedGene.maneSelect,
+    geneLink: validatedGene.hgncId
+      ? `https://search.thegencc.org/genes/${validatedGene.hgncId}`
+      : null,
+  }
+}
+
+/**
+ * Search PubMed literature for a gene, optionally refined by phenotypes.
+ */
+async function searchLiterature(gene, phenotypes = []) {
+  return getPubMedData(gene, phenotypes)
+}
+
 module.exports = getData
 module.exports.analyzeGenes = analyzeGenes
 module.exports.analyzeGenesStructured = analyzeGenesStructured
+module.exports.validateGene = validateGene
+module.exports.searchLiterature = searchLiterature

--- a/services/dataservice.js
+++ b/services/dataservice.js
@@ -7,25 +7,62 @@ const getPanelApps = require('../utils/getPanelApps.js')
 const getClinVarData = require('../utils/getClinVarData.js')
 const fetchOmimData = require('../utils/fetchOMIM.js')
 
+const SOURCE_NAMES = {
+  pubmed: 'PubMed',
+  uniprot: 'UniProt',
+  mouseKO: 'IMPC Mouse Phenotypes',
+  constraints: 'gnomAD Constraints',
+  panelApps: 'PanelApp',
+  clinvar: 'ClinVar',
+  omim: 'OMIM',
+}
+
+const SOURCE_FALLBACKS = {
+  pubmed: { gene: '', url: '', firstArticleTitle: 'No articles found', firstArticleUrl: null, complArticles: [], count: 0, articles: [], articleCount: 0, pubmedUrl: '' },
+  uniprot: { geneFunction: null, bioProcessKeywordsOnly: [], urlAccession: null, bioProcessKeywords: [], uniprotUrl: null },
+  mouseKO: { mousePhenotypes: {}, phenotypeCount: 0, categoryCount: 0, impcUrl: null },
+  constraints: { constraints_v2: { pLI: 'N/A', oe_mis_upper: 'N/A', oe_lof_upper: 'N/A', mis_z: 'N/A' }, constraints_v4: { pLI: 'N/A', oe_mis_upper: 'N/A', oe_lof_upper: 'N/A', mis_z: 'N/A' }, constraintsDelta: false },
+  panelApps: { panelAppEnglandCount: null, panelAppAustraliaCount: null },
+  clinvar: { lofVariants: 0, missenseVariants: 0, lofUnknown: 0, missenseUnknown: 0, totalPathogenic: 0, totalLikelyPathogenic: 0 },
+  omim: { mim: [] },
+}
+
 /**
- * Core gene analysis logic — queries all data sources in parallel per gene.
- * Used by both the Express web app (via getData) and the MCP server.
- *
- * @param {string[]} genes - Gene symbols to analyze
- * @param {string[]} phenotypes - Phenotype terms for PubMed refinement
- * @returns {Promise<Object[]>} - Array of result objects (null entries filtered out)
+ * Unwraps a Promise.allSettled result. Returns the value on success,
+ * or the fallback + error info on failure. Also detects source-level
+ * errors (e.g. ClinVar returned zeros because of a 429).
  */
-async function analyzeGenes(genes, phenotypes = []) {
-  const results = await Promise.all(
+function unwrapSource(settled, key) {
+  if (settled.status === 'rejected') {
+    return {
+      data: { ...SOURCE_FALLBACKS[key] },
+      error: settled.reason?.message || 'Unknown error',
+    }
+  }
+  const data = settled.value
+  // Source resolved but may carry an internal error (e.g. rate limited, timeout).
+  // Some sources (PanelApp) use named error fields instead of a generic 'error' key.
+  const error = data?.error || data?.panelAppEnglandError || data?.panelAppAustraliaError || null
+  return { data, error }
+}
+
+/**
+ * Core gene analysis — queries all data sources in parallel per gene.
+ * Returns structured results with per-source data and explicit error tracking.
+ *
+ * Used by both the web app (via getData, which flattens) and the MCP server
+ * (which uses the structured format directly).
+ */
+async function analyzeGenesStructured(genes, phenotypes = []) {
+  return Promise.all(
     genes.map(async (gene) => {
       try {
         const validatedGene = await fetchGeneCard(gene)
         if (!validatedGene) {
-          return null
+          return { gene, valid: false, error: `Gene symbol "${gene}" not found in HGNC` }
         }
 
-        // Run all data sources in parallel — one failure won't block the rest
-        const [pubmed, uniprot, mouseKO, constraints, panelApps, clinvar, omim] = await Promise.allSettled([
+        const settled = await Promise.allSettled([
           getPubMedData(gene, phenotypes),
           getUniProtFunction(validatedGene.uniprotIds),
           getMouseKO(validatedGene.mgdId),
@@ -35,35 +72,69 @@ async function analyzeGenes(genes, phenotypes = []) {
           fetchOmimData(validatedGene.ensemblGeneId),
         ])
 
-        const unwrap = (result, fallback) =>
-          result.status === 'fulfilled' ? result.value : { ...fallback, error: result.reason?.message }
+        const keys = ['pubmed', 'uniprot', 'mouseKO', 'constraints', 'panelApps', 'clinvar', 'omim']
+        const sources = {}
+        const sourceErrors = []
 
-        const resultData = {
-          ...unwrap(pubmed, { gene, url: '', firstArticleTitle: 'No articles found', firstArticleUrl: null, complArticles: [], count: 0 }),
-          ...unwrap(uniprot, { geneFunction: null, bioProcessKeywordsOnly: [], urlAccession: null }),
-          ...unwrap(mouseKO, { mousePhenotypes: {}, impcUrl: null }),
-          ...unwrap(constraints, { constraints_v2: {}, constraints_v4: {}, constraintsDelta: false }),
-          ...unwrap(panelApps, { panelAppEnglandCount: null, panelAppAustraliaCount: null }),
-          ...unwrap(clinvar, { lofVariants: 0, missenseVariants: 0, lofUnknown: 0, missenseUnknown: 0 }),
-          ...unwrap(omim, { mim: [] }),
-          geneLink: validatedGene.hgncId ? `https://search.thegencc.org/genes/${validatedGene.hgncId}` : '',
-          geneValidity: validatedGene.validityMarker || 'No validity found',
-          hgncId: validatedGene.hgncId || 'No HGNC ID',
-          omimId: validatedGene.omimId || 'No OMIM ID',
+        keys.forEach((key, i) => {
+          const { data, error } = unwrapSource(settled[i], key)
+          sources[key] = data
+          if (error) {
+            sourceErrors.push({ source: SOURCE_NAMES[key], error })
+          }
+        })
+
+        return {
+          gene,
+          valid: true,
+          geneInfo: {
+            name: validatedGene.geneName,
+            alias: validatedGene.aliasName,
+            location: validatedGene.location,
+            hgncId: validatedGene.hgncId,
+            omimId: validatedGene.omimId,
+            ensemblId: validatedGene.ensemblGeneId,
+            geneValidity: validatedGene.validityMarker || 'No Known',
+            geneLink: validatedGene.hgncId
+              ? `https://search.thegencc.org/genes/${validatedGene.hgncId}`
+              : null,
+          },
+          sources,
+          sourceErrors,
         }
-        return resultData
       } catch (error) {
-        console.error(`Error analyzing gene ${gene}: ${error.message}`)
-        return null
+        return { gene, valid: false, error: error.message }
       }
     }),
   )
-
-  return results.filter((result) => result !== null)
 }
 
 /**
- * Express route handler — extracts genes/phenotypes from req.body and calls analyzeGenes.
+ * Flattened version for the web app — spreads all source data into a single object.
+ * Backward-compatible with the original dataservice return shape.
+ */
+async function analyzeGenes(genes, phenotypes = []) {
+  const structured = await analyzeGenesStructured(genes, phenotypes)
+
+  return structured
+    .filter((r) => r.valid)
+    .map((r) => ({
+      ...r.sources.pubmed,
+      ...r.sources.uniprot,
+      ...r.sources.mouseKO,
+      ...r.sources.constraints,
+      ...r.sources.panelApps,
+      ...r.sources.clinvar,
+      ...r.sources.omim,
+      geneLink: r.geneInfo.geneLink || '',
+      geneValidity: r.geneInfo.geneValidity || 'No validity found',
+      hgncId: r.geneInfo.hgncId || 'No HGNC ID',
+      omimId: r.geneInfo.omimId || 'No OMIM ID',
+    }))
+}
+
+/**
+ * Express route handler — extracts genes/phenotypes from req.body.
  */
 async function getData(req) {
   const genes = req.body.genes || []
@@ -73,3 +144,4 @@ async function getData(req) {
 
 module.exports = getData
 module.exports.analyzeGenes = analyzeGenes
+module.exports.analyzeGenesStructured = analyzeGenesStructured

--- a/services/dataservice.js
+++ b/services/dataservice.js
@@ -1,4 +1,3 @@
-// services/dataService.js
 const fetchGeneCard = require('../utils/fetchGeneCard.js')
 const getPubMedData = require('../utils/getPubMedData.js')
 const getUniProtFunction = require('../utils/getUniProtFunction.js')
@@ -7,46 +6,70 @@ const getGeneConstraints = require('../utils/getGeneConstraints.js')
 const getPanelApps = require('../utils/getPanelApps.js')
 const getClinVarData = require('../utils/getClinVarData.js')
 const fetchOmimData = require('../utils/fetchOMIM.js')
-const axios = require('axios')
 
-async function getData(req) {
-  const genes = req.body.genes || []
-  const phenotypes = req.body.phenotypes || []
-
+/**
+ * Core gene analysis logic — queries all data sources in parallel per gene.
+ * Used by both the Express web app (via getData) and the MCP server.
+ *
+ * @param {string[]} genes - Gene symbols to analyze
+ * @param {string[]} phenotypes - Phenotype terms for PubMed refinement
+ * @returns {Promise<Object[]>} - Array of result objects (null entries filtered out)
+ */
+async function analyzeGenes(genes, phenotypes = []) {
   const results = await Promise.all(
     genes.map(async (gene) => {
       try {
-        // * VALIDATE GENE
         const validatedGene = await fetchGeneCard(gene)
         if (!validatedGene) {
           return null
         }
 
-        // * BUILDING RESULT DATA
-        let resultData = {
-          ...(await getPubMedData(gene, phenotypes)), // * PubMed data
-          ...(await getUniProtFunction(validatedGene.uniprotIds)), // * UniProt data
-          ...(await getMouseKO(validatedGene.mgdId)), // * Mouse KO data
-          ...(await getGeneConstraints(gene)), // * Gene constraint data
-          ...(await getPanelApps(gene)), // * PanelApp data
-          ...(await getClinVarData(gene)), // * ClinVar data
-          ...(await fetchOmimData(validatedGene.ensemblGeneId)), // * OMIM data
-          // * ADDITIONNAL
-          geneLink: validatedGene.hgncId ? `https://search.thegencc.org/genes/${validatedGene.hgncId}` : '', // HGNC link
+        // Run all data sources in parallel — one failure won't block the rest
+        const [pubmed, uniprot, mouseKO, constraints, panelApps, clinvar, omim] = await Promise.allSettled([
+          getPubMedData(gene, phenotypes),
+          getUniProtFunction(validatedGene.uniprotIds),
+          getMouseKO(validatedGene.mgdId),
+          getGeneConstraints(gene),
+          getPanelApps(gene),
+          getClinVarData(gene),
+          fetchOmimData(validatedGene.ensemblGeneId),
+        ])
+
+        const unwrap = (result, fallback) =>
+          result.status === 'fulfilled' ? result.value : { ...fallback, error: result.reason?.message }
+
+        const resultData = {
+          ...unwrap(pubmed, { gene, url: '', firstArticleTitle: 'No articles found', firstArticleUrl: null, complArticles: [], count: 0 }),
+          ...unwrap(uniprot, { geneFunction: null, bioProcessKeywordsOnly: [], urlAccession: null }),
+          ...unwrap(mouseKO, { mousePhenotypes: {}, impcUrl: null }),
+          ...unwrap(constraints, { constraints_v2: {}, constraints_v4: {}, constraintsDelta: false }),
+          ...unwrap(panelApps, { panelAppEnglandCount: null, panelAppAustraliaCount: null }),
+          ...unwrap(clinvar, { lofVariants: 0, missenseVariants: 0, lofUnknown: 0, missenseUnknown: 0 }),
+          ...unwrap(omim, { mim: [] }),
+          geneLink: validatedGene.hgncId ? `https://search.thegencc.org/genes/${validatedGene.hgncId}` : '',
           geneValidity: validatedGene.validityMarker || 'No validity found',
           hgncId: validatedGene.hgncId || 'No HGNC ID',
-          omimId: validatedGene.omimId || 'No OMIM ID'
+          omimId: validatedGene.omimId || 'No OMIM ID',
         }
         return resultData
       } catch (error) {
+        console.error(`Error analyzing gene ${gene}: ${error.message}`)
         return null
       }
-    })
+    }),
   )
 
-  // ? Filter out null results useless ?
-  const validResults = results.filter((result) => result !== null)
-  return validResults
+  return results.filter((result) => result !== null)
+}
+
+/**
+ * Express route handler — extracts genes/phenotypes from req.body and calls analyzeGenes.
+ */
+async function getData(req) {
+  const genes = req.body.genes || []
+  const phenotypes = req.body.phenotypes || []
+  return analyzeGenes(genes, phenotypes)
 }
 
 module.exports = getData
+module.exports.analyzeGenes = analyzeGenes

--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -1,0 +1,35 @@
+const { cacheGet, cacheSet, cacheClear } = require('../utils/cache')
+
+describe('cache', () => {
+  beforeEach(() => {
+    cacheClear()
+  })
+
+  test('returns undefined for missing keys', () => {
+    expect(cacheGet('nonexistent')).toBeUndefined()
+  })
+
+  test('stores and retrieves values', () => {
+    cacheSet('key1', { data: 'test' })
+    expect(cacheGet('key1')).toEqual({ data: 'test' })
+  })
+
+  test('returns undefined for expired entries', () => {
+    cacheSet('expired', 'value', 1) // 1ms TTL
+    // Wait for expiry
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        expect(cacheGet('expired')).toBeUndefined()
+        resolve()
+      }, 10)
+    })
+  })
+
+  test('cacheClear removes all entries', () => {
+    cacheSet('a', 1)
+    cacheSet('b', 2)
+    cacheClear()
+    expect(cacheGet('a')).toBeUndefined()
+    expect(cacheGet('b')).toBeUndefined()
+  })
+})

--- a/tests/dataservice.test.js
+++ b/tests/dataservice.test.js
@@ -214,3 +214,6 @@ describe('analyzeGenesStructured — rejected source and crash paths', () => {
     expect(pubmedError.error).toContain('PubMed exploded')
   })
 })
+
+// validateGene and searchLiterature tests are in dataservice-extra.test.js
+// (separate file to avoid jest.mock pollution from the rejected promise tests)

--- a/tests/dataservice.test.js
+++ b/tests/dataservice.test.js
@@ -1,52 +1,215 @@
+const axios = require('axios')
 const { analyzeGenes } = require('../services/dataservice')
 const { cacheClear } = require('../utils/cache')
+
+jest.mock('axios')
+
+// Minimal HGNC XML for fetchGeneCard
+const HGNC_XML = `<?xml version="1.0"?>
+<response>
+  <result name="response" numFound="1">
+    <doc>
+      <str name="name">BRCA DNA repair associated</str>
+      <str name="location">17q21.31</str>
+      <str name="hgnc_id">HGNC:1100</str>
+      <str name="ensembl_gene_id">ENSG00000012048</str>
+      <arr name="alias_name"><str>BRCA1/BRCA2-containing complex subunit 1</str></arr>
+      <arr name="mane_select"><str>NM_007294.4</str></arr>
+      <arr name="mgd_id"><str>MGI:104537</str></arr>
+      <arr name="uniprot_ids"><str>P38398</str></arr>
+      <arr name="omim_id"><str>113705</str></arr>
+    </doc>
+  </result>
+</response>`
+
+// ClinGen validity CSV mock
+const CLINGEN_CSV = `"GENE SYMBOL","GENE ID (HGNC)","DISEASE","CLASSIFICATION"
+"BRCA1","HGNC:1100","Breast cancer","Definitive"`
+
+function setupMocks() {
+  axios.get.mockImplementation((url) => {
+    // HGNC
+    if (url.includes('rest.genenames.org')) {
+      return Promise.resolve({ status: 200, data: HGNC_XML })
+    }
+    // ClinGen
+    if (url.includes('clinicalgenome.org')) {
+      return Promise.resolve({ data: CLINGEN_CSV })
+    }
+    // PubMed esearch
+    if (url.includes('esearch') && url.includes('pubmed')) {
+      return Promise.resolve({
+        data: { esearchresult: { count: '100', idlist: ['12345'] } },
+      })
+    }
+    // PubMed efetch
+    if (url.includes('efetch')) {
+      return Promise.resolve({
+        data: `<PubmedArticleSet><PubmedArticle>
+          <MedlineCitation><PMID>12345</PMID>
+            <Article><ArticleTitle>Test article</ArticleTitle>
+              <Journal><Title>Test Journal</Title><JournalIssue><PubDate><Year>2024</Year></PubDate></JournalIssue></Journal>
+            </Article>
+          </MedlineCitation>
+          <PubmedData><ArticleIdList><ArticleId IdType="pubmed">12345</ArticleId></ArticleIdList></PubmedData>
+        </PubmedArticle></PubmedArticleSet>`,
+      })
+    }
+    // ClinVar esearch
+    if (url.includes('esearch') && url.includes('clinvar')) {
+      return Promise.resolve({
+        data: { esearchresult: { count: '42' } },
+      })
+    }
+    // UniProt protein
+    if (url.includes('ebi.ac.uk/proteins')) {
+      return Promise.resolve({
+        data: {
+          comments: [{ type: 'FUNCTION', text: [{ value: 'E3 ubiquitin-protein ligase' }] }],
+          keywords: [],
+        },
+      })
+    }
+    // UniProt keywords
+    if (url.includes('ftp.uniprot.org')) {
+      return Promise.resolve({ data: '' })
+    }
+    // IMPC mouse KO
+    if (url.includes('ebi.ac.uk/mi/impc')) {
+      return Promise.resolve({
+        data: {
+          response: {
+            docs: [
+              { mp_term_name: 'increased body weight', top_level_mp_term_name: ['growth/size/body region'] },
+            ],
+          },
+        },
+      })
+    }
+    // PanelApp UK
+    if (url.includes('panelapp.genomicsengland')) {
+      return Promise.resolve({ data: { count: 5 } })
+    }
+    // PanelApp Australia
+    if (url.includes('panelapp-aus')) {
+      return Promise.resolve({ data: { count: 2 } })
+    }
+    // Ensembl OMIM
+    if (url.includes('rest.ensembl.org')) {
+      return Promise.resolve({
+        data: [
+          { source: 'MIM morbid', description: 'Breast cancer, familial' },
+          { source: 'MIM morbid', description: 'Ovarian cancer, familial' },
+        ],
+      })
+    }
+    return Promise.reject(new Error(`Unmocked URL: ${url}`))
+  })
+
+  // gnomAD GraphQL
+  axios.post.mockResolvedValue({
+    data: {
+      data: {
+        gene: {
+          gene_id: 'ENSG00000012048',
+          symbol: 'BRCA1',
+          gnomad_constraint: {
+            pLI: 0.0, oe_mis: 0.85, oe_mis_lower: 0.80, oe_mis_upper: 0.92,
+            oe_lof: 0.1, oe_lof_lower: 0.05, oe_lof_upper: 0.15, mis_z: 2.5, lof_z: 4.5,
+          },
+        },
+      },
+    },
+  })
+}
 
 describe('dataservice.analyzeGenes', () => {
   beforeEach(() => {
     cacheClear()
+    jest.clearAllMocks()
+    setupMocks()
   })
 
-  test('analyzes a single gene with all data sources', async () => {
+  test('returns all data sources for a valid gene', async () => {
     const results = await analyzeGenes(['BRCA1'], [])
-    expect(results.length).toBe(1)
-    const result = results[0]
+
+    expect(results).toHaveLength(1)
+    const r = results[0]
 
     // Gene info
-    expect(result.hgncId).toBeTruthy()
-    expect(result.geneValidity).toBeTruthy()
+    expect(r.hgncId).toBe('HGNC:1100')
+    expect(r.geneValidity).toBeDefined()
 
-    // PubMed (legacy keys)
-    expect(typeof result.count).toBe('number')
-    expect(result.count).toBeGreaterThan(0)
+    // PubMed
+    expect(r.count).toBe(100)
+    expect(r.firstArticleTitle).toBe('Test article')
 
     // ClinVar
-    expect(typeof result.lofVariants).toBe('number')
-    expect(typeof result.totalPathogenic).toBe('number')
+    expect(r.lofVariants).toBe(42)
+    expect(r.clinvarUrl).toContain('BRCA1')
 
     // gnomAD
-    expect(result.constraints_v2).toBeDefined()
-    expect(result.constraints_v4).toBeDefined()
-    expect(typeof result.constraintsDelta).toBe('boolean')
+    expect(r.constraints_v4).toBeDefined()
+    expect(r.constraints_v4.pLI).toBe(0)
+    expect(r.gnomadUrl).toContain('BRCA1')
+
+    // UniProt
+    expect(r.geneFunction).toContain('ubiquitin')
 
     // PanelApp
-    expect(result.panelAppEnglandCount !== undefined || result.panelAppEnglandError !== undefined).toBe(true)
+    expect(r.panelAppEnglandCount).toBe(5)
+    expect(r.panelAppAustraliaCount).toBe(2)
+
+    // Mouse KO
+    expect(r.mousePhenotypes).toBeDefined()
 
     // OMIM
-    expect(result.mim).toBeDefined()
-  }, 120000)
+    expect(r.mim).toContain('Breast cancer, familial')
+    expect(r.mim).toContain('Ovarian cancer, familial')
+  })
 
-  test('filters out invalid genes', async () => {
-    const results = await analyzeGenes(['XYZNOTAREALGENE123'], [])
-    expect(results.length).toBe(0) // Null results are filtered
-  }, 30000)
+  test('filters out invalid genes (returns empty)', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('rest.genenames.org')) {
+        return Promise.resolve({
+          status: 200,
+          data: '<response><result name="response" numFound="0"></result></response>',
+        })
+      }
+      return Promise.resolve({ data: {} })
+    })
 
-  test('handles multiple genes in parallel', async () => {
-    const results = await analyzeGenes(['BRCA1', 'TP53'], [])
-    expect(results.length).toBe(2)
-    // Both should have data
-    for (const result of results) {
-      expect(result.hgncId).toBeTruthy()
-      expect(typeof result.count).toBe('number')
-    }
-  }, 120000)
+    const results = await analyzeGenes(['XYZFAKE'], [])
+    expect(results).toHaveLength(0)
+  })
+
+  test('runs data sources in parallel (Promise.allSettled)', async () => {
+    // Make PanelApp fail — other sources should still return data
+    axios.get.mockImplementation((url) => {
+      if (url.includes('panelapp')) {
+        return Promise.reject(new Error('PanelApp down'))
+      }
+      // Default mocks for everything else
+      if (url.includes('rest.genenames.org')) return Promise.resolve({ status: 200, data: HGNC_XML })
+      if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: CLINGEN_CSV })
+      if (url.includes('esearch') && url.includes('pubmed')) return Promise.resolve({ data: { esearchresult: { count: '10', idlist: ['111'] } } })
+      if (url.includes('efetch')) return Promise.resolve({ data: '<PubmedArticleSet><PubmedArticle><MedlineCitation><PMID>111</PMID><Article><ArticleTitle>Test</ArticleTitle><Journal><Title>J</Title><JournalIssue><PubDate><Year>2024</Year></PubDate></JournalIssue></Journal></Article></MedlineCitation><PubmedData><ArticleIdList><ArticleId IdType="pubmed">111</ArticleId></ArticleIdList></PubmedData></PubmedArticle></PubmedArticleSet>' })
+      if (url.includes('esearch') && url.includes('clinvar')) return Promise.resolve({ data: { esearchresult: { count: '5' } } })
+      if (url.includes('ebi.ac.uk/proteins')) return Promise.resolve({ data: { comments: [], keywords: [] } })
+      if (url.includes('ftp.uniprot.org')) return Promise.resolve({ data: '' })
+      if (url.includes('ebi.ac.uk/mi/impc')) return Promise.resolve({ data: { response: { docs: [] } } })
+      if (url.includes('rest.ensembl.org')) return Promise.resolve({ data: [] })
+      return Promise.reject(new Error(`Unmocked: ${url}`))
+    })
+
+    const results = await analyzeGenes(['BRCA1'], [])
+    expect(results).toHaveLength(1)
+
+    // PubMed still works
+    expect(results[0].count).toBe(10)
+    // ClinVar still works
+    expect(results[0].lofVariants).toBe(5)
+    // PanelApp failed gracefully
+    expect(results[0].panelAppEnglandCount).toBeNull()
+  })
 })

--- a/tests/dataservice.test.js
+++ b/tests/dataservice.test.js
@@ -150,3 +150,67 @@ describe('analyzeGenes (flat)', () => {
     expect(results).toHaveLength(0)
   })
 })
+
+describe('getData (Express handler)', () => {
+  beforeEach(() => {
+    cacheClear()
+    resetLimiter()
+    jest.clearAllMocks()
+    setupMocks()
+  })
+
+  test('extracts genes/phenotypes from req.body and returns results', async () => {
+    const getData = require('../services/dataservice')
+    const req = { body: { genes: ['BRCA1'], phenotypes: ['cancer'] } }
+    const results = await getData(req)
+    expect(results).toHaveLength(1)
+    expect(results[0].hgncId).toBe('HGNC:1100')
+  })
+
+  test('handles empty req.body gracefully', async () => {
+    const getData = require('../services/dataservice')
+    const results = await getData({ body: {} })
+    expect(results).toEqual([])
+  })
+})
+
+describe('analyzeGenesStructured — rejected source and crash paths', () => {
+  test('unwrapSource handles rejected promises from data sources', async () => {
+    // Use jest.resetModules to mock a specific util to reject
+    jest.resetModules()
+    const freshDataservice = require('../services/dataservice')
+    const freshCache = require('../utils/cache')
+    freshCache.cacheClear()
+
+    // Mock fetchGeneCard to return a valid gene
+    jest.mock('../utils/fetchGeneCard.js', () => {
+      return jest.fn().mockResolvedValue({
+        geneName: 'Test', aliasName: null, location: '1p', maneSelect: null,
+        mgdId: null, enzymeId: null, uniprotIds: null, hgncId: 'HGNC:999',
+        rgdId: null, ensemblGeneId: null, orphanet: null, dateModified: null,
+        dateApprovedReserved: null, validityMarker: 'No Known', omimId: null,
+      })
+    })
+    // Mock PubMed to REJECT (triggers the rejected path in unwrapSource)
+    jest.mock('../utils/getPubMedData.js', () => jest.fn().mockRejectedValue(new Error('PubMed exploded')))
+    // Mock everything else to resolve normally
+    jest.mock('../utils/getUniProtFunction.js', () => jest.fn().mockResolvedValue({ geneFunction: null, bioProcessKeywordsOnly: [], urlAccession: null, bioProcessKeywords: [], uniprotUrl: null }))
+    jest.mock('../utils/getMouseKO.js', () => jest.fn().mockResolvedValue({ mousePhenotypes: {}, phenotypeCount: 0, categoryCount: 0, impcUrl: null }))
+    jest.mock('../utils/getGeneConstraints.js', () => jest.fn().mockResolvedValue({ constraints_v2: {}, constraints_v4: {}, constraintsDelta: false }))
+    jest.mock('../utils/getPanelApps.js', () => jest.fn().mockResolvedValue({ panelAppEnglandCount: 0, panelAppAustraliaCount: 0, panelAppEnglandError: null, panelAppAustraliaError: null }))
+    jest.mock('../utils/getClinVarData.js', () => jest.fn().mockResolvedValue({ lofVariants: 0, missenseVariants: 0, lofUnknown: 0, missenseUnknown: 0, totalPathogenic: 0, totalLikelyPathogenic: 0 }))
+    jest.mock('../utils/fetchOMIM.js', () => jest.fn().mockResolvedValue({ mim: [] }))
+
+    // Re-require to pick up mocks
+    jest.resetModules()
+    const { analyzeGenesStructured: freshAnalyze } = require('../services/dataservice')
+
+    const results = await freshAnalyze(['TEST'], [])
+    expect(results).toHaveLength(1)
+    expect(results[0].valid).toBe(true)
+    // PubMed should be in sourceErrors
+    const pubmedError = results[0].sourceErrors.find((e) => e.source === 'PubMed')
+    expect(pubmedError).toBeDefined()
+    expect(pubmedError.error).toContain('PubMed exploded')
+  })
+})

--- a/tests/dataservice.test.js
+++ b/tests/dataservice.test.js
@@ -1,10 +1,10 @@
 const axios = require('axios')
-const { analyzeGenes } = require('../services/dataservice')
+const { analyzeGenes, analyzeGenesStructured } = require('../services/dataservice')
 const { cacheClear } = require('../utils/cache')
+const { resetLimiter } = require('../utils/rateLimiter')
 
 jest.mock('axios')
 
-// Minimal HGNC XML for fetchGeneCard
 const HGNC_XML = `<?xml version="1.0"?>
 <response>
   <result name="response" numFound="1">
@@ -13,7 +13,7 @@ const HGNC_XML = `<?xml version="1.0"?>
       <str name="location">17q21.31</str>
       <str name="hgnc_id">HGNC:1100</str>
       <str name="ensembl_gene_id">ENSG00000012048</str>
-      <arr name="alias_name"><str>BRCA1/BRCA2-containing complex subunit 1</str></arr>
+      <arr name="alias_name"><str>BRCC1</str></arr>
       <arr name="mane_select"><str>NM_007294.4</str></arr>
       <arr name="mgd_id"><str>MGI:104537</str></arr>
       <arr name="uniprot_ids"><str>P38398</str></arr>
@@ -22,176 +22,65 @@ const HGNC_XML = `<?xml version="1.0"?>
   </result>
 </response>`
 
-// ClinGen validity CSV mock
 const CLINGEN_CSV = `"GENE SYMBOL","GENE ID (HGNC)","DISEASE","CLASSIFICATION"
 "BRCA1","HGNC:1100","Breast cancer","Definitive"`
 
 function setupMocks() {
   axios.get.mockImplementation((url) => {
-    // HGNC
-    if (url.includes('rest.genenames.org')) {
-      return Promise.resolve({ status: 200, data: HGNC_XML })
-    }
-    // ClinGen
-    if (url.includes('clinicalgenome.org')) {
-      return Promise.resolve({ data: CLINGEN_CSV })
-    }
-    // PubMed esearch
-    if (url.includes('esearch') && url.includes('pubmed')) {
-      return Promise.resolve({
-        data: { esearchresult: { count: '100', idlist: ['12345'] } },
-      })
-    }
-    // PubMed efetch
-    if (url.includes('efetch')) {
-      return Promise.resolve({
-        data: `<PubmedArticleSet><PubmedArticle>
-          <MedlineCitation><PMID>12345</PMID>
-            <Article><ArticleTitle>Test article</ArticleTitle>
-              <Journal><Title>Test Journal</Title><JournalIssue><PubDate><Year>2024</Year></PubDate></JournalIssue></Journal>
-            </Article>
-          </MedlineCitation>
-          <PubmedData><ArticleIdList><ArticleId IdType="pubmed">12345</ArticleId></ArticleIdList></PubmedData>
-        </PubmedArticle></PubmedArticleSet>`,
-      })
-    }
-    // ClinVar esearch
-    if (url.includes('esearch') && url.includes('clinvar')) {
-      return Promise.resolve({
-        data: { esearchresult: { count: '42' } },
-      })
-    }
-    // UniProt protein
-    if (url.includes('ebi.ac.uk/proteins')) {
-      return Promise.resolve({
-        data: {
-          comments: [{ type: 'FUNCTION', text: [{ value: 'E3 ubiquitin-protein ligase' }] }],
-          keywords: [],
-        },
-      })
-    }
-    // UniProt keywords
-    if (url.includes('ftp.uniprot.org')) {
-      return Promise.resolve({ data: '' })
-    }
-    // IMPC mouse KO
-    if (url.includes('ebi.ac.uk/mi/impc')) {
-      return Promise.resolve({
-        data: {
-          response: {
-            docs: [
-              { mp_term_name: 'increased body weight', top_level_mp_term_name: ['growth/size/body region'] },
-            ],
-          },
-        },
-      })
-    }
-    // PanelApp UK
-    if (url.includes('panelapp.genomicsengland')) {
-      return Promise.resolve({ data: { count: 5 } })
-    }
-    // PanelApp Australia
-    if (url.includes('panelapp-aus')) {
-      return Promise.resolve({ data: { count: 2 } })
-    }
-    // Ensembl OMIM
-    if (url.includes('rest.ensembl.org')) {
-      return Promise.resolve({
-        data: [
-          { source: 'MIM morbid', description: 'Breast cancer, familial' },
-          { source: 'MIM morbid', description: 'Ovarian cancer, familial' },
-        ],
-      })
-    }
+    if (url.includes('rest.genenames.org')) return Promise.resolve({ status: 200, data: HGNC_XML })
+    if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: CLINGEN_CSV })
+    if (url.includes('esearch') && url.includes('pubmed')) return Promise.resolve({ data: { esearchresult: { count: '100', idlist: ['12345'] } } })
+    if (url.includes('efetch')) return Promise.resolve({ data: '<PubmedArticleSet><PubmedArticle><MedlineCitation><PMID>12345</PMID><Article><ArticleTitle>Test article</ArticleTitle><Journal><Title>J</Title><JournalIssue><PubDate><Year>2024</Year></PubDate></JournalIssue></Journal></Article></MedlineCitation><PubmedData><ArticleIdList><ArticleId IdType="pubmed">12345</ArticleId></ArticleIdList></PubmedData></PubmedArticle></PubmedArticleSet>' })
+    if (url.includes('esearch') && url.includes('clinvar')) return Promise.resolve({ data: { esearchresult: { count: '42' } } })
+    if (url.includes('ebi.ac.uk/proteins')) return Promise.resolve({ data: { comments: [{ type: 'FUNCTION', text: [{ value: 'E3 ubiquitin-protein ligase' }] }], keywords: [] } })
+    if (url.includes('ftp.uniprot.org')) return Promise.resolve({ data: '' })
+    if (url.includes('ebi.ac.uk/mi/impc')) return Promise.resolve({ data: { response: { docs: [{ mp_term_name: 'increased body weight', top_level_mp_term_name: ['growth/size/body region'] }] } } })
+    if (url.includes('panelapp.genomicsengland')) return Promise.resolve({ data: { count: 5 } })
+    if (url.includes('panelapp-aus')) return Promise.resolve({ data: { count: 2 } })
+    if (url.includes('rest.ensembl.org')) return Promise.resolve({ data: [{ source: 'MIM morbid', description: 'Breast cancer, familial' }] })
     return Promise.reject(new Error(`Unmocked URL: ${url}`))
   })
 
-  // gnomAD GraphQL
   axios.post.mockResolvedValue({
-    data: {
-      data: {
-        gene: {
-          gene_id: 'ENSG00000012048',
-          symbol: 'BRCA1',
-          gnomad_constraint: {
-            pLI: 0.0, oe_mis: 0.85, oe_mis_lower: 0.80, oe_mis_upper: 0.92,
-            oe_lof: 0.1, oe_lof_lower: 0.05, oe_lof_upper: 0.15, mis_z: 2.5, lof_z: 4.5,
-          },
-        },
-      },
-    },
+    data: { data: { gene: { gene_id: 'ENSG00000012048', symbol: 'BRCA1', gnomad_constraint: { pLI: 0.0, oe_mis: 0.85, oe_mis_lower: 0.80, oe_mis_upper: 0.92, oe_lof: 0.1, oe_lof_lower: 0.05, oe_lof_upper: 0.15, mis_z: 2.5, lof_z: 4.5 } } } },
   })
 }
 
-describe('dataservice.analyzeGenes', () => {
+describe('analyzeGenesStructured', () => {
   beforeEach(() => {
     cacheClear()
+    resetLimiter()
     jest.clearAllMocks()
     setupMocks()
   })
 
-  test('returns all data sources for a valid gene', async () => {
-    const results = await analyzeGenes(['BRCA1'], [])
-
+  test('returns structured result with per-source data', async () => {
+    const results = await analyzeGenesStructured(['BRCA1'], [])
     expect(results).toHaveLength(1)
+
     const r = results[0]
+    expect(r.valid).toBe(true)
+    expect(r.gene).toBe('BRCA1')
+    expect(r.geneInfo.hgncId).toBe('HGNC:1100')
+    expect(r.geneInfo.geneValidity).toBe('Definitive')
 
-    // Gene info
-    expect(r.hgncId).toBe('HGNC:1100')
-    expect(r.geneValidity).toBeDefined()
+    // Per-source data
+    expect(r.sources.pubmed.articleCount).toBe(100)
+    expect(r.sources.clinvar.lofVariants).toBe(42)
+    expect(r.sources.constraints.constraints_v4.pLI).toBe(0)
+    expect(r.sources.uniprot.geneFunction).toContain('ubiquitin')
+    expect(r.sources.panelApps.panelAppEnglandCount).toBe(5)
+    expect(r.sources.omim.mim).toContain('Breast cancer, familial')
 
-    // PubMed
-    expect(r.count).toBe(100)
-    expect(r.firstArticleTitle).toBe('Test article')
-
-    // ClinVar
-    expect(r.lofVariants).toBe(42)
-    expect(r.clinvarUrl).toContain('BRCA1')
-
-    // gnomAD
-    expect(r.constraints_v4).toBeDefined()
-    expect(r.constraints_v4.pLI).toBe(0)
-    expect(r.gnomadUrl).toContain('BRCA1')
-
-    // UniProt
-    expect(r.geneFunction).toContain('ubiquitin')
-
-    // PanelApp
-    expect(r.panelAppEnglandCount).toBe(5)
-    expect(r.panelAppAustraliaCount).toBe(2)
-
-    // Mouse KO
-    expect(r.mousePhenotypes).toBeDefined()
-
-    // OMIM
-    expect(r.mim).toContain('Breast cancer, familial')
-    expect(r.mim).toContain('Ovarian cancer, familial')
+    // No errors
+    expect(r.sourceErrors).toEqual([])
   })
 
-  test('filters out invalid genes (returns empty)', async () => {
+  test('tracks source errors without crashing', async () => {
     axios.get.mockImplementation((url) => {
-      if (url.includes('rest.genenames.org')) {
-        return Promise.resolve({
-          status: 200,
-          data: '<response><result name="response" numFound="0"></result></response>',
-        })
-      }
-      return Promise.resolve({ data: {} })
-    })
-
-    const results = await analyzeGenes(['XYZFAKE'], [])
-    expect(results).toHaveLength(0)
-  })
-
-  test('runs data sources in parallel (Promise.allSettled)', async () => {
-    // Make PanelApp fail — other sources should still return data
-    axios.get.mockImplementation((url) => {
-      if (url.includes('panelapp')) {
-        return Promise.reject(new Error('PanelApp down'))
-      }
-      // Default mocks for everything else
       if (url.includes('rest.genenames.org')) return Promise.resolve({ status: 200, data: HGNC_XML })
       if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: CLINGEN_CSV })
+      if (url.includes('panelapp')) return Promise.reject(new Error('PanelApp down'))
       if (url.includes('esearch') && url.includes('pubmed')) return Promise.resolve({ data: { esearchresult: { count: '10', idlist: ['111'] } } })
       if (url.includes('efetch')) return Promise.resolve({ data: '<PubmedArticleSet><PubmedArticle><MedlineCitation><PMID>111</PMID><Article><ArticleTitle>Test</ArticleTitle><Journal><Title>J</Title><JournalIssue><PubDate><Year>2024</Year></PubDate></JournalIssue></Journal></Article></MedlineCitation><PubmedData><ArticleIdList><ArticleId IdType="pubmed">111</ArticleId></ArticleIdList></PubmedData></PubmedArticle></PubmedArticleSet>' })
       if (url.includes('esearch') && url.includes('clinvar')) return Promise.resolve({ data: { esearchresult: { count: '5' } } })
@@ -202,14 +91,62 @@ describe('dataservice.analyzeGenes', () => {
       return Promise.reject(new Error(`Unmocked: ${url}`))
     })
 
+    const results = await analyzeGenesStructured(['BRCA1'], [])
+    const r = results[0]
+
+    // Other sources still work
+    expect(r.sources.pubmed.articleCount).toBe(10)
+    expect(r.sources.clinvar.lofVariants).toBe(5)
+
+    // PanelApp error tracked
+    expect(r.sourceErrors).toHaveLength(1)
+    expect(r.sourceErrors[0].source).toBe('PanelApp')
+    expect(r.sourceErrors[0].error).toContain('unavailable')
+  })
+
+  test('returns valid=false for unknown genes', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: CLINGEN_CSV })
+      if (url.includes('rest.genenames.org')) return Promise.resolve({ status: 200, data: '<response><result name="response" numFound="0"></result></response>' })
+      return Promise.resolve({ data: {} })
+    })
+
+    const results = await analyzeGenesStructured(['XYZFAKE'], [])
+    expect(results).toHaveLength(1)
+    expect(results[0].valid).toBe(false)
+    expect(results[0].error).toContain('not found')
+  })
+})
+
+describe('analyzeGenes (flat)', () => {
+  beforeEach(() => {
+    cacheClear()
+    resetLimiter()
+    jest.clearAllMocks()
+    setupMocks()
+  })
+
+  test('returns flat result for web app backward compat', async () => {
     const results = await analyzeGenes(['BRCA1'], [])
     expect(results).toHaveLength(1)
 
-    // PubMed still works
-    expect(results[0].count).toBe(10)
-    // ClinVar still works
-    expect(results[0].lofVariants).toBe(5)
-    // PanelApp failed gracefully
-    expect(results[0].panelAppEnglandCount).toBeNull()
+    const r = results[0]
+    // Flat keys (no .sources nesting)
+    expect(r.count).toBe(100)
+    expect(r.lofVariants).toBe(42)
+    expect(r.hgncId).toBe('HGNC:1100')
+    expect(r.geneValidity).toBe('Definitive')
+    expect(r.mim).toContain('Breast cancer, familial')
+  })
+
+  test('filters out invalid genes', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: CLINGEN_CSV })
+      if (url.includes('rest.genenames.org')) return Promise.resolve({ status: 200, data: '<response><result name="response" numFound="0"></result></response>' })
+      return Promise.resolve({ data: {} })
+    })
+
+    const results = await analyzeGenes(['XYZFAKE'], [])
+    expect(results).toHaveLength(0)
   })
 })

--- a/tests/dataservice.test.js
+++ b/tests/dataservice.test.js
@@ -1,0 +1,52 @@
+const { analyzeGenes } = require('../services/dataservice')
+const { cacheClear } = require('../utils/cache')
+
+describe('dataservice.analyzeGenes', () => {
+  beforeEach(() => {
+    cacheClear()
+  })
+
+  test('analyzes a single gene with all data sources', async () => {
+    const results = await analyzeGenes(['BRCA1'], [])
+    expect(results.length).toBe(1)
+    const result = results[0]
+
+    // Gene info
+    expect(result.hgncId).toBeTruthy()
+    expect(result.geneValidity).toBeTruthy()
+
+    // PubMed (legacy keys)
+    expect(typeof result.count).toBe('number')
+    expect(result.count).toBeGreaterThan(0)
+
+    // ClinVar
+    expect(typeof result.lofVariants).toBe('number')
+    expect(typeof result.totalPathogenic).toBe('number')
+
+    // gnomAD
+    expect(result.constraints_v2).toBeDefined()
+    expect(result.constraints_v4).toBeDefined()
+    expect(typeof result.constraintsDelta).toBe('boolean')
+
+    // PanelApp
+    expect(result.panelAppEnglandCount !== undefined || result.panelAppEnglandError !== undefined).toBe(true)
+
+    // OMIM
+    expect(result.mim).toBeDefined()
+  }, 120000)
+
+  test('filters out invalid genes', async () => {
+    const results = await analyzeGenes(['XYZNOTAREALGENE123'], [])
+    expect(results.length).toBe(0) // Null results are filtered
+  }, 30000)
+
+  test('handles multiple genes in parallel', async () => {
+    const results = await analyzeGenes(['BRCA1', 'TP53'], [])
+    expect(results.length).toBe(2)
+    // Both should have data
+    for (const result of results) {
+      expect(result.hgncId).toBeTruthy()
+      expect(typeof result.count).toBe('number')
+    }
+  }, 120000)
+})

--- a/tests/fetchGeneCard.test.js
+++ b/tests/fetchGeneCard.test.js
@@ -1,8 +1,8 @@
-const axios = require('axios')
-const fetchGeneCard = require('../utils/fetchGeneCard')
 const { cacheClear } = require('../utils/cache')
 
-jest.mock('axios')
+// Cannot use top-level jest.mock('axios') because we need jest.resetModules()
+// to reset the ClinGen validity map singleton between tests.
+// Instead, we mock axios in each test via jest.resetModules().
 
 const HGNC_XML = `<?xml version="1.0"?>
 <response>
@@ -24,21 +24,29 @@ const HGNC_XML = `<?xml version="1.0"?>
 const CLINGEN_CSV = `"GENE SYMBOL","GENE ID (HGNC)","DISEASE LABEL","CLASSIFICATION","GCEP"
 "BRCA1","HGNC:1100","Breast cancer","Definitive","Some GCEP"`
 
-describe('fetchGeneCard', () => {
-  beforeEach(() => {
-    cacheClear()
-    jest.clearAllMocks()
-  })
+const CLINGEN_CSV_MULTI = `"GENE SYMBOL","GENE ID (HGNC)","DISEASE LABEL","CLASSIFICATION","GCEP"
+"GENE1","HGNC:1100","Disease A","Limited","GCEP1"
+"GENE1","HGNC:1100","Disease B","Definitive","GCEP2"`
 
+function loadFresh(axiosMockSetup) {
+  jest.resetModules()
+  const axios = require('axios')
+  jest.spyOn(axios, 'get').mockImplementation(axiosMockSetup)
+  const fetchGeneCard = require('../utils/fetchGeneCard')
+  const cache = require('../utils/cache')
+  cache.cacheClear()
+  return { fetchGeneCard, axios, cache }
+}
+
+describe('fetchGeneCard', () => {
   test('parses HGNC XML and returns Gene object with ClinGen validity', async () => {
-    axios.get.mockImplementation((url) => {
+    const { fetchGeneCard } = loadFresh((url) => {
       if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: CLINGEN_CSV })
       if (url.includes('rest.genenames.org')) return Promise.resolve({ status: 200, data: HGNC_XML })
       return Promise.reject(new Error(`Unmocked: ${url}`))
     })
 
     const gene = await fetchGeneCard('BRCA1')
-
     expect(gene).toBeTruthy()
     expect(gene.geneName).toBe('BRCA DNA repair associated')
     expect(gene.location).toBe('17q21.31')
@@ -49,35 +57,73 @@ describe('fetchGeneCard', () => {
     expect(gene.validityMarker).toBe('Definitive')
   })
 
-  test('returns false when gene not found', async () => {
-    axios.get.mockImplementation((url) => {
+  test('returns false when gene not found (numFound=0)', async () => {
+    const { fetchGeneCard } = loadFresh((url) => {
       if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: CLINGEN_CSV })
-      if (url.includes('rest.genenames.org')) {
-        return Promise.resolve({
-          status: 200,
-          data: '<response><result name="response" numFound="0"></result></response>',
-        })
-      }
+      if (url.includes('rest.genenames.org')) return Promise.resolve({ status: 200, data: '<response><result name="response" numFound="0"></result></response>' })
       return Promise.reject(new Error(`Unmocked: ${url}`))
     })
 
-    const result = await fetchGeneCard('XYZFAKE')
-    expect(result).toBe(false)
+    expect(await fetchGeneCard('XYZFAKE')).toBe(false)
+  })
+
+  test('returns null when HGNC responds with non-200 status', async () => {
+    const { fetchGeneCard } = loadFresh((url) => {
+      if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: CLINGEN_CSV })
+      if (url.includes('rest.genenames.org')) return Promise.resolve({ status: 503, data: '' })
+      return Promise.reject(new Error(`Unmocked: ${url}`))
+    })
+
+    expect(await fetchGeneCard('BRCA1')).toBeNull()
   })
 
   test('returns null on API error', async () => {
-    axios.get.mockImplementation((url) => {
+    const { fetchGeneCard } = loadFresh((url) => {
       if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: CLINGEN_CSV })
       if (url.includes('rest.genenames.org')) return Promise.reject(new Error('timeout'))
       return Promise.reject(new Error(`Unmocked: ${url}`))
     })
 
-    const result = await fetchGeneCard('BRCA1')
-    expect(result).toBeNull()
+    expect(await fetchGeneCard('BRCA1')).toBeNull()
+  })
+
+  test('handles ClinGen CSV with no matching header', async () => {
+    const { fetchGeneCard } = loadFresh((url) => {
+      if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: 'random,csv,data\n1,2,3' })
+      if (url.includes('rest.genenames.org')) return Promise.resolve({ status: 200, data: HGNC_XML })
+      return Promise.reject(new Error(`Unmocked: ${url}`))
+    })
+
+    const gene = await fetchGeneCard('BRCA1')
+    expect(gene).toBeTruthy()
+    expect(gene.validityMarker).toBe('No Known')
+  })
+
+  test('handles ClinGen download failure gracefully', async () => {
+    const { fetchGeneCard } = loadFresh((url) => {
+      if (url.includes('clinicalgenome.org')) return Promise.reject(new Error('ClinGen down'))
+      if (url.includes('rest.genenames.org')) return Promise.resolve({ status: 200, data: HGNC_XML })
+      return Promise.reject(new Error(`Unmocked: ${url}`))
+    })
+
+    const gene = await fetchGeneCard('BRCA1')
+    expect(gene).toBeTruthy()
+    expect(gene.validityMarker).toBe('No Known')
+  })
+
+  test('ClinGen keeps highest classification for duplicate HGNC IDs', async () => {
+    const { fetchGeneCard } = loadFresh((url) => {
+      if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: CLINGEN_CSV_MULTI })
+      if (url.includes('rest.genenames.org')) return Promise.resolve({ status: 200, data: HGNC_XML })
+      return Promise.reject(new Error(`Unmocked: ${url}`))
+    })
+
+    const gene = await fetchGeneCard('BRCA1')
+    expect(gene.validityMarker).toBe('Definitive')
   })
 
   test('caches gene results', async () => {
-    axios.get.mockImplementation((url) => {
+    const { fetchGeneCard, axios } = loadFresh((url) => {
       if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: CLINGEN_CSV })
       if (url.includes('rest.genenames.org')) return Promise.resolve({ status: 200, data: HGNC_XML })
       return Promise.reject(new Error(`Unmocked: ${url}`))
@@ -86,7 +132,6 @@ describe('fetchGeneCard', () => {
     const result1 = await fetchGeneCard('BRCA1')
     const result2 = await fetchGeneCard('BRCA1')
     expect(result2).toEqual(result1)
-    // HGNC should only be called once (ClinGen download may be called once too)
     const hgncCalls = axios.get.mock.calls.filter((c) => c[0].includes('rest.genenames.org'))
     expect(hgncCalls).toHaveLength(1)
   })

--- a/tests/fetchGeneCard.test.js
+++ b/tests/fetchGeneCard.test.js
@@ -1,0 +1,93 @@
+const axios = require('axios')
+const fetchGeneCard = require('../utils/fetchGeneCard')
+const { cacheClear } = require('../utils/cache')
+
+jest.mock('axios')
+
+const HGNC_XML = `<?xml version="1.0"?>
+<response>
+  <result name="response" numFound="1">
+    <doc>
+      <str name="name">BRCA DNA repair associated</str>
+      <str name="location">17q21.31</str>
+      <str name="hgnc_id">HGNC:1100</str>
+      <str name="ensembl_gene_id">ENSG00000012048</str>
+      <arr name="alias_name"><str>BRCC1</str></arr>
+      <arr name="mane_select"><str>NM_007294.4</str></arr>
+      <arr name="mgd_id"><str>MGI:104537</str></arr>
+      <arr name="uniprot_ids"><str>P38398</str></arr>
+      <arr name="omim_id"><str>113705</str></arr>
+    </doc>
+  </result>
+</response>`
+
+const CLINGEN_CSV = `"GENE SYMBOL","GENE ID (HGNC)","DISEASE LABEL","CLASSIFICATION","GCEP"
+"BRCA1","HGNC:1100","Breast cancer","Definitive","Some GCEP"`
+
+describe('fetchGeneCard', () => {
+  beforeEach(() => {
+    cacheClear()
+    jest.clearAllMocks()
+  })
+
+  test('parses HGNC XML and returns Gene object with ClinGen validity', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: CLINGEN_CSV })
+      if (url.includes('rest.genenames.org')) return Promise.resolve({ status: 200, data: HGNC_XML })
+      return Promise.reject(new Error(`Unmocked: ${url}`))
+    })
+
+    const gene = await fetchGeneCard('BRCA1')
+
+    expect(gene).toBeTruthy()
+    expect(gene.geneName).toBe('BRCA DNA repair associated')
+    expect(gene.location).toBe('17q21.31')
+    expect(gene.hgncId).toBe('HGNC:1100')
+    expect(gene.ensemblGeneId).toBe('ENSG00000012048')
+    expect(gene.uniprotIds).toBe('P38398')
+    expect(gene.omimId).toBe('113705')
+    expect(gene.validityMarker).toBe('Definitive')
+  })
+
+  test('returns false when gene not found', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: CLINGEN_CSV })
+      if (url.includes('rest.genenames.org')) {
+        return Promise.resolve({
+          status: 200,
+          data: '<response><result name="response" numFound="0"></result></response>',
+        })
+      }
+      return Promise.reject(new Error(`Unmocked: ${url}`))
+    })
+
+    const result = await fetchGeneCard('XYZFAKE')
+    expect(result).toBe(false)
+  })
+
+  test('returns null on API error', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: CLINGEN_CSV })
+      if (url.includes('rest.genenames.org')) return Promise.reject(new Error('timeout'))
+      return Promise.reject(new Error(`Unmocked: ${url}`))
+    })
+
+    const result = await fetchGeneCard('BRCA1')
+    expect(result).toBeNull()
+  })
+
+  test('caches gene results', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: CLINGEN_CSV })
+      if (url.includes('rest.genenames.org')) return Promise.resolve({ status: 200, data: HGNC_XML })
+      return Promise.reject(new Error(`Unmocked: ${url}`))
+    })
+
+    const result1 = await fetchGeneCard('BRCA1')
+    const result2 = await fetchGeneCard('BRCA1')
+    expect(result2).toEqual(result1)
+    // HGNC should only be called once (ClinGen download may be called once too)
+    const hgncCalls = axios.get.mock.calls.filter((c) => c[0].includes('rest.genenames.org'))
+    expect(hgncCalls).toHaveLength(1)
+  })
+})

--- a/tests/fetchOMIM.test.js
+++ b/tests/fetchOMIM.test.js
@@ -1,0 +1,48 @@
+const axios = require('axios')
+const fetchOmimData = require('../utils/fetchOMIM')
+const { cacheClear } = require('../utils/cache')
+
+jest.mock('axios')
+
+describe('fetchOmimData', () => {
+  beforeEach(() => {
+    cacheClear()
+    jest.clearAllMocks()
+  })
+
+  test('extracts MIM morbid descriptions with deduplication', async () => {
+    axios.get.mockResolvedValue({
+      data: [
+        { source: 'MIM morbid', description: 'Breast cancer, familial' },
+        { source: 'MIM morbid', description: 'Ovarian cancer, familial' },
+        { source: 'MIM morbid', description: 'Breast cancer, familial' }, // duplicate
+        { source: 'ClinVar', description: 'Something else' }, // wrong source
+      ],
+    })
+
+    const result = await fetchOmimData('ENSG00000012048')
+    expect(result.mim).toEqual(['Breast cancer, familial', 'Ovarian cancer, familial'])
+  })
+
+  test('returns empty when no ensemblId', async () => {
+    const result = await fetchOmimData(null)
+    expect(result.mim).toEqual([])
+    expect(axios.get).not.toHaveBeenCalled()
+  })
+
+  test('returns empty on API error', async () => {
+    axios.get.mockRejectedValue(new Error('Ensembl timeout'))
+
+    const result = await fetchOmimData('ENSG00000012048')
+    expect(result.mim).toEqual([])
+    expect(result.error).toBe('Ensembl timeout')
+  })
+
+  test('caches results', async () => {
+    axios.get.mockResolvedValue({ data: [{ source: 'MIM morbid', description: 'Test' }] })
+
+    await fetchOmimData('ENSG00000012048')
+    await fetchOmimData('ENSG00000012048')
+    expect(axios.get).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/fetchOMIM.test.js
+++ b/tests/fetchOMIM.test.js
@@ -30,6 +30,16 @@ describe('fetchOmimData', () => {
     expect(axios.get).not.toHaveBeenCalled()
   })
 
+  test('uses "No description" fallback when description is missing', async () => {
+    axios.get.mockResolvedValue({
+      data: [
+        { source: 'MIM morbid' }, // no description field
+      ],
+    })
+    const result = await fetchOmimData('ENSG00000012048')
+    expect(result.mim).toEqual(['No description'])
+  })
+
   test('returns empty on API error', async () => {
     axios.get.mockRejectedValue(new Error('Ensembl timeout'))
 

--- a/tests/formatters.test.js
+++ b/tests/formatters.test.js
@@ -188,4 +188,120 @@ describe('formatLiterature', () => {
     expect(result).toContain('0')
     expect(result).not.toContain('###')
   })
+
+  test('handles article with no authors, no DOI, no abstract, no citation', () => {
+    const result = formatLiterature({
+      gene: 'X', articleCount: 1, articles: [{
+        title: 'Bare', authors: [], journal: '', year: '', pmid: '999', doi: '', abstract: '',
+      }],
+    })
+    expect(result).toContain('### Bare')
+    expect(result).toContain('999')
+    expect(result).not.toContain('**Authors**')
+    expect(result).not.toContain('**Published in**')
+    expect(result).not.toContain('**DOI**')
+  })
+
+  test('handles article with null pubmedUrl', () => {
+    const result = formatLiterature({ gene: 'X', articleCount: 0, articles: [], pubmedUrl: null })
+    expect(result).not.toContain('Full PubMed search')
+  })
+})
+
+describe('formatGeneAnalysis — edge cases', () => {
+  test('skips UniProt section when geneFunction is null', () => {
+    const result = formatGeneAnalysis([{
+      gene: 'X', valid: true,
+      geneInfo: { name: 'X', geneValidity: 'No Known' },
+      sources: {
+        uniprot: { geneFunction: null, bioProcessKeywords: [] },
+        constraints: { constraints_v4: { pLI: 'N/A' }, constraints_v2: { pLI: 'N/A' } },
+        clinvar: { lofVariants: 0, missenseVariants: 0, lofUnknown: 0, missenseUnknown: 0, totalPathogenic: 0, totalLikelyPathogenic: 0 },
+        pubmed: { articleCount: 0, articles: [] },
+        panelApps: { panelAppEnglandCount: null, panelAppAustraliaCount: null },
+        mouseKO: { phenotypeCount: 0, mousePhenotypes: {} },
+        omim: { mim: [] },
+      },
+      sourceErrors: [],
+    }])
+    // UniProt still renders because geneFunction is null but no error
+    expect(result).toContain('No function data available')
+  })
+
+  test('renders gene with no geneLink', () => {
+    const result = formatGeneAnalysis([{
+      gene: 'X', valid: true,
+      geneInfo: { name: 'X', hgncId: null, geneValidity: 'No Known', geneLink: null },
+      sources: {
+        uniprot: {}, constraints: { constraints_v4: { pLI: 'N/A' }, constraints_v2: { pLI: 'N/A' } },
+        clinvar: { lofVariants: 0, missenseVariants: 0, lofUnknown: 0, missenseUnknown: 0, totalPathogenic: 0, totalLikelyPathogenic: 0 },
+        pubmed: { articleCount: 0, articles: [] }, panelApps: {}, mouseKO: { phenotypeCount: 0, mousePhenotypes: {} }, omim: { mim: [] },
+      },
+      sourceErrors: [],
+    }])
+    expect(result).not.toContain('GenCC')
+  })
+
+  test('renders PubMed article with no authors and partial citation', () => {
+    const result = formatGeneAnalysis([{
+      gene: 'X', valid: true,
+      geneInfo: { name: 'X', geneValidity: 'No Known' },
+      sources: {
+        uniprot: {}, constraints: { constraints_v4: { pLI: 'N/A' }, constraints_v2: { pLI: 'N/A' } },
+        clinvar: { lofVariants: 0, missenseVariants: 0, lofUnknown: 0, missenseUnknown: 0, totalPathogenic: 0, totalLikelyPathogenic: 0 },
+        pubmed: { articleCount: 1, articles: [{ title: 'Solo', authors: [], journal: 'Nature', year: '', pmid: '1', doi: '' }], pubmedUrl: 'http://x' },
+        panelApps: {}, mouseKO: { phenotypeCount: 0, mousePhenotypes: {} }, omim: { mim: [] },
+      },
+      sourceErrors: [],
+    }])
+    expect(result).toContain('Solo')
+    expect(result).toContain('Nature')
+  })
+
+  test('renders PanelApp with error strings instead of counts', () => {
+    const result = formatGeneAnalysis([{
+      gene: 'X', valid: true,
+      geneInfo: { name: 'X', geneValidity: 'No Known' },
+      sources: {
+        uniprot: {}, constraints: { constraints_v4: { pLI: 'N/A' }, constraints_v2: { pLI: 'N/A' } },
+        clinvar: { lofVariants: 0, missenseVariants: 0, lofUnknown: 0, missenseUnknown: 0, totalPathogenic: 0, totalLikelyPathogenic: 0 },
+        pubmed: { articleCount: 0, articles: [] },
+        panelApps: { panelAppEnglandCount: null, panelAppEnglandError: 'UK unavailable', panelAppAustraliaCount: null, panelAppAustraliaError: 'AUS unavailable' },
+        mouseKO: { phenotypeCount: 0, mousePhenotypes: {} }, omim: { mim: [] },
+      },
+      sourceErrors: [],
+    }])
+    expect(result).toContain('UK unavailable')
+    expect(result).toContain('AUS unavailable')
+  })
+
+  test('renders mouse phenotypes with flat array format', () => {
+    const result = formatGeneAnalysis([{
+      gene: 'X', valid: true,
+      geneInfo: { name: 'X', geneValidity: 'No Known' },
+      sources: {
+        uniprot: {}, constraints: { constraints_v4: { pLI: 'N/A' }, constraints_v2: { pLI: 'N/A' } },
+        clinvar: { lofVariants: 0, missenseVariants: 0, lofUnknown: 0, missenseUnknown: 0, totalPathogenic: 0, totalLikelyPathogenic: 0 },
+        pubmed: { articleCount: 0, articles: [] }, panelApps: {},
+        mouseKO: { phenotypeCount: 2, categoryCount: 1, mousePhenotypes: { growth: ['Weight gain', 'Size increase'] }, impcUrl: 'http://impc' },
+        omim: { mim: [] },
+      },
+      sourceErrors: [],
+    }])
+    expect(result).toContain('Weight gain, Size increase')
+  })
+
+  test('renders constraintsDelta note', () => {
+    const result = formatGeneAnalysis([{
+      gene: 'X', valid: true,
+      geneInfo: { name: 'X', geneValidity: 'No Known' },
+      sources: {
+        uniprot: {}, constraints: { constraints_v4: { pLI: 0.99, oe_lof_upper: 0.1, oe_mis_upper: 0.9, mis_z: 3.0 }, constraints_v2: { pLI: 0.2, oe_lof_upper: 0.5, oe_mis_upper: 0.8, mis_z: 1.0 }, constraintsDelta: true, gnomadUrl: 'http://gnomad' },
+        clinvar: { lofVariants: 0, missenseVariants: 0, lofUnknown: 0, missenseUnknown: 0, totalPathogenic: 0, totalLikelyPathogenic: 0 },
+        pubmed: { articleCount: 0, articles: [] }, panelApps: {}, mouseKO: { phenotypeCount: 0, mousePhenotypes: {} }, omim: { mim: [] },
+      },
+      sourceErrors: [],
+    }])
+    expect(result).toContain('Significant difference')
+  })
 })

--- a/tests/formatters.test.js
+++ b/tests/formatters.test.js
@@ -1,0 +1,191 @@
+const { formatGeneAnalysis, formatValidation, formatLiterature, formatSourceErrors } = require('../utils/formatters')
+
+describe('formatSourceErrors', () => {
+  test('returns empty string when no errors', () => {
+    expect(formatSourceErrors([])).toBe('')
+    expect(formatSourceErrors(null)).toBe('')
+  })
+
+  test('formats error list with source names', () => {
+    const result = formatSourceErrors([
+      { source: 'ClinVar', error: 'Request failed with status code 429' },
+      { source: 'OMIM', error: 'timeout of 30000ms exceeded' },
+    ])
+    expect(result).toContain('Data Source Warnings')
+    expect(result).toContain('**ClinVar**: unavailable')
+    expect(result).toContain('**OMIM**: unavailable')
+  })
+})
+
+describe('formatGeneAnalysis', () => {
+  test('returns fallback for empty results', () => {
+    expect(formatGeneAnalysis([])).toBe('No results returned.')
+    expect(formatGeneAnalysis(null)).toBe('No results returned.')
+  })
+
+  test('formats invalid gene with error', () => {
+    const result = formatGeneAnalysis([{ gene: 'FAKE', valid: false, error: 'Not found in HGNC' }])
+    expect(result).toContain('## FAKE')
+    expect(result).toContain('Not found in HGNC')
+  })
+
+  test('formats full gene analysis with all sources', () => {
+    const result = formatGeneAnalysis([{
+      gene: 'BRCA1',
+      valid: true,
+      geneInfo: {
+        name: 'BRCA DNA repair', hgncId: 'HGNC:1100', location: '17q21', alias: 'BRCC1',
+        omimId: '113705', ensemblId: 'ENSG00000012048', geneValidity: 'Definitive',
+        geneLink: 'https://search.thegencc.org/genes/HGNC:1100',
+      },
+      sources: {
+        uniprot: { geneFunction: 'E3 ubiquitin-protein ligase', bioProcessKeywords: ['Apoptosis'], uniprotUrl: 'https://uniprot.org/P38398' },
+        constraints: { constraints_v4: { pLI: 0.0, oe_lof_upper: 0.15, oe_mis_upper: 0.92, mis_z: 2.5 }, constraints_v2: { pLI: 0.0, oe_lof_upper: 0.12, oe_mis_upper: 0.90, mis_z: 2.3 }, constraintsDelta: false, gnomadUrl: 'https://gnomad.broadinstitute.org/gene/BRCA1' },
+        clinvar: { lofVariants: 15, missenseVariants: 230, lofUnknown: 5, missenseUnknown: 890, totalPathogenic: 450, totalLikelyPathogenic: 120, clinvarUrl: 'https://clinvar/BRCA1' },
+        pubmed: { articleCount: 42567, articles: [{ title: 'BRCA2 gene mutation', authors: ['Smith JA'], journal: 'Cancer Res', year: '2022', pmid: '36397405', doi: '10.1234/test' }], pubmedUrl: 'https://pubmed/BRCA1' },
+        panelApps: { panelAppEnglandCount: 5, panelAppAustraliaCount: 2 },
+        mouseKO: { phenotypeCount: 3, categoryCount: 2, mousePhenotypes: { growth: { names: ['Increased body weight'] }, behavior: { names: ['Decreased grip strength'] } }, impcUrl: 'https://impc/MGI:104537' },
+        omim: { mim: ['Breast cancer, familial'] },
+      },
+      sourceErrors: [],
+    }])
+
+    expect(result).toContain('## BRCA1 — BRCA DNA repair')
+    expect(result).toContain('HGNC:1100')
+    expect(result).toContain('Definitive')
+    expect(result).toContain('E3 ubiquitin-protein ligase')
+    expect(result).toContain('Apoptosis')
+    expect(result).toContain('pLI=0')
+    expect(result).toContain('Pathogenic LoF variants')
+    expect(result).toContain('42567')
+    expect(result).toContain('BRCA2 gene mutation')
+    expect(result).toContain('Smith JA')
+    expect(result).toContain('Genomics England')
+    expect(result).toContain('Increased body weight')
+    expect(result).toContain('Breast cancer, familial')
+    expect(result).not.toContain('Data Source Warnings')
+  })
+
+  test('includes source warnings when sources failed', () => {
+    const result = formatGeneAnalysis([{
+      gene: 'TP53', valid: true,
+      geneInfo: { name: 'TP53', hgncId: 'HGNC:11998', geneValidity: 'Definitive' },
+      sources: {
+        uniprot: { error: 'timeout' },
+        constraints: { constraints_v4: { pLI: 'N/A' }, constraints_v2: { pLI: 'N/A' }, constraintsDelta: false },
+        clinvar: { error: '429 rate limited' },
+        pubmed: { articleCount: 100, articles: [], pubmedUrl: 'https://pubmed/TP53' },
+        panelApps: { panelAppEnglandCount: 3, panelAppAustraliaCount: 1 },
+        mouseKO: { phenotypeCount: 0, mousePhenotypes: {} },
+        omim: { mim: [] },
+      },
+      sourceErrors: [
+        { source: 'UniProt', error: 'timeout' },
+        { source: 'ClinVar', error: '429 rate limited' },
+      ],
+    }])
+
+    expect(result).toContain('Data Source Warnings')
+    expect(result).toContain('**UniProt**: unavailable')
+    expect(result).toContain('**ClinVar**: unavailable')
+    expect(result).not.toContain('### UniProt Function')
+    expect(result).not.toContain('### ClinVar Variants')
+    expect(result).toContain('### PubMed Literature')
+  })
+
+  test('handles gnomAD N/A data', () => {
+    const result = formatGeneAnalysis([{
+      gene: 'X', valid: true,
+      geneInfo: { name: 'X', geneValidity: 'No Known' },
+      sources: {
+        uniprot: { geneFunction: null }, constraints: { constraints_v4: { pLI: 'N/A' }, constraints_v2: { pLI: 'N/A' }, constraintsDelta: false },
+        clinvar: { lofVariants: 0, missenseVariants: 0, lofUnknown: 0, missenseUnknown: 0, totalPathogenic: 0, totalLikelyPathogenic: 0 },
+        pubmed: { articleCount: 0, articles: [] }, panelApps: { panelAppEnglandCount: 0 },
+        mouseKO: { phenotypeCount: 0, mousePhenotypes: {} }, omim: { mim: [] },
+      },
+      sourceErrors: [],
+    }])
+
+    expect(result).toContain('No data available')
+  })
+
+  test('separates multiple genes with ---', () => {
+    const result = formatGeneAnalysis([
+      { gene: 'A', valid: true, geneInfo: { name: 'Gene A', geneValidity: 'X' }, sources: { uniprot: {}, constraints: { constraints_v4: { pLI: 'N/A' }, constraints_v2: { pLI: 'N/A' } }, clinvar: { lofVariants: 0, missenseVariants: 0, lofUnknown: 0, missenseUnknown: 0, totalPathogenic: 0, totalLikelyPathogenic: 0 }, pubmed: { articleCount: 0, articles: [] }, panelApps: {}, mouseKO: { phenotypeCount: 0, mousePhenotypes: {} }, omim: { mim: [] } }, sourceErrors: [] },
+      { gene: 'B', valid: true, geneInfo: { name: 'Gene B', geneValidity: 'Y' }, sources: { uniprot: {}, constraints: { constraints_v4: { pLI: 'N/A' }, constraints_v2: { pLI: 'N/A' } }, clinvar: { lofVariants: 0, missenseVariants: 0, lofUnknown: 0, missenseUnknown: 0, totalPathogenic: 0, totalLikelyPathogenic: 0 }, pubmed: { articleCount: 0, articles: [] }, panelApps: {}, mouseKO: { phenotypeCount: 0, mousePhenotypes: {} }, omim: { mim: [] } }, sourceErrors: [] },
+    ])
+    expect(result).toContain('---')
+    expect(result).toContain('## A — Gene A')
+    expect(result).toContain('## B — Gene B')
+  })
+})
+
+describe('formatValidation', () => {
+  test('formats invalid gene', () => {
+    const result = formatValidation({ valid: false, gene: 'FAKE', message: 'Not found in HGNC' })
+    expect(result).toContain('**FAKE**')
+    expect(result).toContain('Not found in HGNC')
+  })
+
+  test('formats valid gene with all fields', () => {
+    const result = formatValidation({
+      valid: true, gene: 'BRCA1', name: 'BRCA DNA repair', alias: 'BRCC1',
+      location: '17q21', hgncId: 'HGNC:1100', omimId: '113705',
+      ensemblId: 'ENSG00000012048', geneValidity: 'Definitive',
+      maneSelect: ['NM_007294.4'], geneLink: 'https://gencc/HGNC:1100',
+    })
+    expect(result).toContain('## BRCA1 — Validated')
+    expect(result).toContain('BRCA DNA repair')
+    expect(result).toContain('HGNC:1100')
+    expect(result).toContain('Definitive')
+    expect(result).toContain('NM_007294.4')
+    expect(result).toContain('GenCC')
+  })
+
+  test('handles missing optional fields', () => {
+    const result = formatValidation({
+      valid: true, gene: 'X', name: null, alias: null,
+      location: null, hgncId: null, omimId: null,
+      ensemblId: null, geneValidity: null, maneSelect: null, geneLink: null,
+    })
+    expect(result).toContain('N/A')
+    expect(result).toContain('No Known')
+    expect(result).not.toContain('MANE Select')
+    expect(result).not.toContain('GenCC')
+  })
+})
+
+describe('formatLiterature', () => {
+  test('formats articles with full metadata', () => {
+    const result = formatLiterature({
+      gene: 'BRCA1', articleCount: 42567, pubmedUrl: 'https://pubmed/BRCA1',
+      articles: [{
+        title: 'Test article', authors: ['Smith JA', 'Doe B'], journal: 'Nature',
+        year: '2024', pmid: '12345', doi: '10.1234/test', abstract: 'This is the abstract.',
+      }],
+    })
+    expect(result).toContain('## PubMed results for BRCA1')
+    expect(result).toContain('42567')
+    expect(result).toContain('### Test article')
+    expect(result).toContain('Smith JA, Doe B')
+    expect(result).toContain('Nature, 2024')
+    expect(result).toContain('10.1234/test')
+    expect(result).toContain('12345')
+    expect(result).toContain('This is the abstract')
+    expect(result).toContain('Full PubMed search')
+  })
+
+  test('includes warning when error is present', () => {
+    const result = formatLiterature({
+      gene: 'X', articleCount: 0, articles: [], error: '429 rate limited',
+    })
+    expect(result).toContain('**Warning**')
+    expect(result).toContain('429 rate limited')
+  })
+
+  test('handles empty articles', () => {
+    const result = formatLiterature({ gene: 'X', articleCount: 0, articles: [] })
+    expect(result).toContain('0')
+    expect(result).not.toContain('###')
+  })
+})

--- a/tests/getClinVarData.test.js
+++ b/tests/getClinVarData.test.js
@@ -1,46 +1,74 @@
+const axios = require('axios')
 const getClinVarData = require('../utils/getClinVarData')
 const { cacheClear } = require('../utils/cache')
+
+jest.mock('axios')
+
+function mockClinVarCount(count) {
+  return { data: { esearchresult: { count: String(count) } } }
+}
 
 describe('getClinVarData', () => {
   beforeEach(() => {
     cacheClear()
+    jest.clearAllMocks()
   })
 
-  test('returns correct shape for a known gene', async () => {
+  test('queries ClinVar API for all variant categories', async () => {
+    axios.get
+      .mockResolvedValueOnce(mockClinVarCount(15))  // pathogenic LoF
+      .mockResolvedValueOnce(mockClinVarCount(230))  // pathogenic missense
+      .mockResolvedValueOnce(mockClinVarCount(5))    // VUS LoF
+      .mockResolvedValueOnce(mockClinVarCount(890))  // VUS missense
+      .mockResolvedValueOnce(mockClinVarCount(450))  // total pathogenic
+      .mockResolvedValueOnce(mockClinVarCount(120))  // total likely pathogenic
+
     const result = await getClinVarData('BRCA1')
-    expect(result).toBeDefined()
-    // Always returns these keys (even on rate limit / error)
-    expect(typeof result.lofVariants).toBe('number')
-    expect(typeof result.missenseVariants).toBe('number')
-    expect(typeof result.lofUnknown).toBe('number')
-    expect(typeof result.missenseUnknown).toBe('number')
-    expect(typeof result.totalPathogenic).toBe('number')
-    expect(typeof result.totalLikelyPathogenic).toBe('number')
-    expect(result.clinvarUrl).toContain('clinvar')
-    expect(result.clinvarUrl).toContain('BRCA1')
 
-    // If API responded (no rate limit), values should be positive
-    if (!result.error) {
-      expect(result.totalPathogenic).toBeGreaterThan(0)
-    }
-  }, 60000)
+    expect(result.lofVariants).toBe(15)
+    expect(result.missenseVariants).toBe(230)
+    expect(result.lofUnknown).toBe(5)
+    expect(result.missenseUnknown).toBe(890)
+    expect(result.totalPathogenic).toBe(450)
+    expect(result.totalLikelyPathogenic).toBe(120)
+    expect(result.clinvarUrl).toBe('https://www.ncbi.nlm.nih.gov/clinvar/?term=BRCA1[gene]')
 
-  test('returns zeros for unknown gene', async () => {
-    const result = await getClinVarData('XYZNOTAREALGENE123')
+    // Verify correct API calls
+    expect(axios.get).toHaveBeenCalledTimes(6)
+    const calls = axios.get.mock.calls.map((c) => c[0])
+    expect(calls[0]).toContain('pathogenic')
+    expect(calls[0]).toContain('loss of function')
+    expect(calls[1]).toContain('pathogenic')
+    expect(calls[1]).toContain('missense')
+    expect(calls[4]).toContain('pathogenic')
+    expect(calls[4]).not.toContain('molecular_consequence')
+  })
+
+  test('returns zeros on API error', async () => {
+    axios.get.mockRejectedValueOnce(new Error('429 Too Many Requests'))
+
+    const result = await getClinVarData('BRCA1')
+
     expect(result.lofVariants).toBe(0)
     expect(result.missenseVariants).toBe(0)
     expect(result.totalPathogenic).toBe(0)
-  }, 60000)
+    expect(result.error).toBe('429 Too Many Requests')
+    expect(result.clinvarUrl).toContain('BRCA1')
+  })
 
-  test('caches successful results', async () => {
+  test('caches results', async () => {
+    axios.get
+      .mockResolvedValueOnce(mockClinVarCount(10))
+      .mockResolvedValueOnce(mockClinVarCount(20))
+      .mockResolvedValueOnce(mockClinVarCount(1))
+      .mockResolvedValueOnce(mockClinVarCount(50))
+      .mockResolvedValueOnce(mockClinVarCount(100))
+      .mockResolvedValueOnce(mockClinVarCount(30))
+
     const result1 = await getClinVarData('TP53')
-    // Only test caching if first call succeeded (not rate-limited)
-    if (!result1.error) {
-      const start = Date.now()
-      const result2 = await getClinVarData('TP53')
-      const elapsed = Date.now() - start
-      expect(result2).toEqual(result1)
-      expect(elapsed).toBeLessThan(50)
-    }
-  }, 60000)
+    const result2 = await getClinVarData('TP53')
+
+    expect(result2).toEqual(result1)
+    expect(axios.get).toHaveBeenCalledTimes(6) // Only first call hits API
+  })
 })

--- a/tests/getClinVarData.test.js
+++ b/tests/getClinVarData.test.js
@@ -1,0 +1,46 @@
+const getClinVarData = require('../utils/getClinVarData')
+const { cacheClear } = require('../utils/cache')
+
+describe('getClinVarData', () => {
+  beforeEach(() => {
+    cacheClear()
+  })
+
+  test('returns correct shape for a known gene', async () => {
+    const result = await getClinVarData('BRCA1')
+    expect(result).toBeDefined()
+    // Always returns these keys (even on rate limit / error)
+    expect(typeof result.lofVariants).toBe('number')
+    expect(typeof result.missenseVariants).toBe('number')
+    expect(typeof result.lofUnknown).toBe('number')
+    expect(typeof result.missenseUnknown).toBe('number')
+    expect(typeof result.totalPathogenic).toBe('number')
+    expect(typeof result.totalLikelyPathogenic).toBe('number')
+    expect(result.clinvarUrl).toContain('clinvar')
+    expect(result.clinvarUrl).toContain('BRCA1')
+
+    // If API responded (no rate limit), values should be positive
+    if (!result.error) {
+      expect(result.totalPathogenic).toBeGreaterThan(0)
+    }
+  }, 60000)
+
+  test('returns zeros for unknown gene', async () => {
+    const result = await getClinVarData('XYZNOTAREALGENE123')
+    expect(result.lofVariants).toBe(0)
+    expect(result.missenseVariants).toBe(0)
+    expect(result.totalPathogenic).toBe(0)
+  }, 60000)
+
+  test('caches successful results', async () => {
+    const result1 = await getClinVarData('TP53')
+    // Only test caching if first call succeeded (not rate-limited)
+    if (!result1.error) {
+      const start = Date.now()
+      const result2 = await getClinVarData('TP53')
+      const elapsed = Date.now() - start
+      expect(result2).toEqual(result1)
+      expect(elapsed).toBeLessThan(50)
+    }
+  }, 60000)
+})

--- a/tests/getClinVarData.test.js
+++ b/tests/getClinVarData.test.js
@@ -1,8 +1,12 @@
-const axios = require('axios')
 const getClinVarData = require('../utils/getClinVarData')
 const { cacheClear } = require('../utils/cache')
+const { rateLimitedGet } = require('../utils/rateLimiter')
 
-jest.mock('axios')
+// Mock rateLimitedGet (not axios) — rate limiter behavior is tested in rateLimiter.test.js
+jest.mock('../utils/rateLimiter', () => ({
+  rateLimitedGet: jest.fn(),
+  resetLimiter: jest.fn(),
+}))
 
 function mockClinVarCount(count) {
   return { data: { esearchresult: { count: String(count) } } }
@@ -14,8 +18,8 @@ describe('getClinVarData', () => {
     jest.clearAllMocks()
   })
 
-  test('queries ClinVar API for all variant categories', async () => {
-    axios.get
+  test('queries ClinVar API for all variant categories via Promise.all', async () => {
+    rateLimitedGet
       .mockResolvedValueOnce(mockClinVarCount(15))  // pathogenic LoF
       .mockResolvedValueOnce(mockClinVarCount(230))  // pathogenic missense
       .mockResolvedValueOnce(mockClinVarCount(5))    // VUS LoF
@@ -33,31 +37,29 @@ describe('getClinVarData', () => {
     expect(result.totalLikelyPathogenic).toBe(120)
     expect(result.clinvarUrl).toBe('https://www.ncbi.nlm.nih.gov/clinvar/?term=BRCA1[gene]')
 
-    // Verify correct API calls
-    expect(axios.get).toHaveBeenCalledTimes(6)
-    const calls = axios.get.mock.calls.map((c) => c[0])
-    expect(calls[0]).toContain('pathogenic')
-    expect(calls[0]).toContain('loss of function')
-    expect(calls[1]).toContain('pathogenic')
-    expect(calls[1]).toContain('missense')
-    expect(calls[4]).toContain('pathogenic')
-    expect(calls[4]).not.toContain('molecular_consequence')
+    // 6 queries fired via Promise.all
+    expect(rateLimitedGet).toHaveBeenCalledTimes(6)
+    const urls = rateLimitedGet.mock.calls.map((c) => c[1])
+    expect(urls[0]).toContain('pathogenic')
+    expect(urls[0]).toContain('loss of function')
+    expect(urls[1]).toContain('missense')
+    expect(urls[4]).not.toContain('molecular_consequence')
   })
 
   test('returns zeros on API error', async () => {
-    axios.get.mockRejectedValueOnce(new Error('429 Too Many Requests'))
+    rateLimitedGet.mockRejectedValue(new Error('429 Too Many Requests'))
 
     const result = await getClinVarData('BRCA1')
 
     expect(result.lofVariants).toBe(0)
     expect(result.missenseVariants).toBe(0)
     expect(result.totalPathogenic).toBe(0)
-    expect(result.error).toBe('429 Too Many Requests')
+    expect(result.error).toBeTruthy()
     expect(result.clinvarUrl).toContain('BRCA1')
   })
 
-  test('caches results', async () => {
-    axios.get
+  test('caches results on second call', async () => {
+    rateLimitedGet
       .mockResolvedValueOnce(mockClinVarCount(10))
       .mockResolvedValueOnce(mockClinVarCount(20))
       .mockResolvedValueOnce(mockClinVarCount(1))
@@ -69,6 +71,6 @@ describe('getClinVarData', () => {
     const result2 = await getClinVarData('TP53')
 
     expect(result2).toEqual(result1)
-    expect(axios.get).toHaveBeenCalledTimes(6) // Only first call hits API
+    expect(rateLimitedGet).toHaveBeenCalledTimes(6)
   })
 })

--- a/tests/getClinVarData.test.js
+++ b/tests/getClinVarData.test.js
@@ -58,6 +58,14 @@ describe('getClinVarData', () => {
     expect(result.clinvarUrl).toContain('BRCA1')
   })
 
+  test('handles undefined/null count from API response', async () => {
+    rateLimitedGet.mockResolvedValue({ data: { esearchresult: {} } })
+
+    const result = await getClinVarData('NOCOUNTS')
+    expect(result.lofVariants).toBe(0)
+    expect(result.totalPathogenic).toBe(0)
+  })
+
   test('caches results on second call', async () => {
     rateLimitedGet
       .mockResolvedValueOnce(mockClinVarCount(10))

--- a/tests/getGeneConstraints.test.js
+++ b/tests/getGeneConstraints.test.js
@@ -1,37 +1,108 @@
+const axios = require('axios')
 const getGeneConstraints = require('../utils/getGeneConstraints')
 const { cacheClear } = require('../utils/cache')
+
+jest.mock('axios')
+
+function mockGnomadResponse(pLI, oe_mis_upper, oe_lof_upper, mis_z) {
+  return {
+    data: {
+      data: {
+        gene: {
+          gene_id: 'ENSG00000012048',
+          symbol: 'BRCA1',
+          gnomad_constraint: {
+            pLI: pLI,
+            oe_mis: 0.85,
+            oe_mis_lower: 0.80,
+            oe_mis_upper: oe_mis_upper,
+            oe_lof: 0.1,
+            oe_lof_lower: 0.05,
+            oe_lof_upper: oe_lof_upper,
+            mis_z: mis_z,
+            lof_z: 4.5,
+          },
+        },
+      },
+    },
+  }
+}
 
 describe('getGeneConstraints', () => {
   beforeEach(() => {
     cacheClear()
+    jest.clearAllMocks()
   })
 
-  test('returns constraint scores for a known gene', async () => {
-    const result = await getGeneConstraints('BRCA1')
-    expect(result).toBeDefined()
-    expect(result.constraints_v2).toBeDefined()
-    expect(result.constraints_v4).toBeDefined()
-    expect(typeof result.constraintsDelta).toBe('boolean')
-    // Check v4 has real data
-    expect(result.constraints_v4.pLI).not.toBe('N/A')
-    expect(typeof result.constraints_v4.pLI).toBe('number')
-    // New field
-    expect(result.gnomadUrl).toContain('gnomad.broadinstitute.org')
-  }, 30000)
+  test('queries gnomAD GraphQL API for v2 and v4', async () => {
+    axios.post
+      .mockResolvedValueOnce(mockGnomadResponse(0.99, 0.92, 0.15, 2.5)) // v4
+      .mockResolvedValueOnce(mockGnomadResponse(0.98, 0.90, 0.12, 2.3)) // v2
 
-  test('returns N/A for unknown gene', async () => {
-    const result = await getGeneConstraints('XYZNOTAREALGENE123')
+    const result = await getGeneConstraints('BRCA1')
+
+    expect(result.constraints_v4.pLI).toBe(0.99)
+    expect(result.constraints_v4.oe_mis_upper).toBe(0.92)
+    expect(result.constraints_v4.oe_lof_upper).toBe(0.15)
+    expect(result.constraints_v4.mis_z).toBe(2.5)
+
+    expect(result.constraints_v2.pLI).toBe(0.98)
+    expect(result.constraints_v2.oe_lof_upper).toBe(0.12)
+
+    expect(result.gnomadUrl).toBe('https://gnomad.broadinstitute.org/gene/BRCA1?dataset=gnomad_r4')
+
+    // Both queries sent in parallel
+    expect(axios.post).toHaveBeenCalledTimes(2)
+    expect(axios.post.mock.calls[0][0]).toBe('https://gnomad.broadinstitute.org/api')
+  })
+
+  test('detects significant delta between v2 and v4', async () => {
+    axios.post
+      .mockResolvedValueOnce(mockGnomadResponse(0.99, 0.92, 0.15, 2.5)) // v4 high pLI
+      .mockResolvedValueOnce(mockGnomadResponse(0.30, 0.90, 0.12, 2.3)) // v2 low pLI (>1.5x diff)
+
+    const result = await getGeneConstraints('GENE1')
+    expect(result.constraintsDelta).toBe(true)
+  })
+
+  test('no delta when scores are similar', async () => {
+    axios.post
+      .mockResolvedValueOnce(mockGnomadResponse(0.95, 0.92, 0.15, 2.5))
+      .mockResolvedValueOnce(mockGnomadResponse(0.90, 0.90, 0.12, 2.3))
+
+    const result = await getGeneConstraints('GENE2')
+    expect(result.constraintsDelta).toBe(false)
+  })
+
+  test('returns N/A when gene not found in gnomAD', async () => {
+    axios.post
+      .mockResolvedValueOnce({ data: { data: { gene: null } } })
+      .mockResolvedValueOnce({ data: { data: { gene: null } } })
+
+    const result = await getGeneConstraints('FAKEGENE')
     expect(result.constraints_v2.pLI).toBe('N/A')
     expect(result.constraints_v4.pLI).toBe('N/A')
     expect(result.constraintsDelta).toBe(false)
-  }, 30000)
+  })
+
+  test('returns fallback on API error', async () => {
+    axios.post.mockRejectedValueOnce(new Error('timeout'))
+
+    const result = await getGeneConstraints('BRCA1')
+    expect(result.constraints_v2.pLI).toBe('N/A')
+    expect(result.error).toBe('timeout')
+    expect(result.gnomadUrl).toContain('BRCA1')
+  })
 
   test('caches results', async () => {
+    axios.post
+      .mockResolvedValueOnce(mockGnomadResponse(0.99, 0.92, 0.15, 2.5))
+      .mockResolvedValueOnce(mockGnomadResponse(0.98, 0.90, 0.12, 2.3))
+
     const result1 = await getGeneConstraints('TP53')
-    const start = Date.now()
     const result2 = await getGeneConstraints('TP53')
-    const elapsed = Date.now() - start
+
     expect(result2).toEqual(result1)
-    expect(elapsed).toBeLessThan(50)
-  }, 30000)
+    expect(axios.post).toHaveBeenCalledTimes(2) // Only first call
+  })
 })

--- a/tests/getGeneConstraints.test.js
+++ b/tests/getGeneConstraints.test.js
@@ -94,6 +94,37 @@ describe('getGeneConstraints', () => {
     expect(result.error).toBe('timeout')
   })
 
+  test('extractConstraints returns all fields when data is present', async () => {
+    axios.post
+      .mockResolvedValueOnce(mockGnomadResponse(0.99, 0.92, 0.15, 2.5))
+      .mockResolvedValueOnce(mockGnomadResponse(0.98, 0.90, 0.12, 2.3))
+
+    const result = await getGeneConstraints('FULL')
+    // Verify all extracted fields
+    const v4 = result.constraints_v4
+    expect(v4.pLI).toBe(0.99)
+    expect(v4.oe_mis_upper).toBe(0.92)
+    expect(v4.oe_lof_upper).toBe(0.15)
+    expect(v4.mis_z).toBe(2.5)
+    expect(v4.oe_mis).toBe(0.85)
+    expect(v4.oe_lof).toBe(0.1)
+    expect(v4.lof_z).toBe(4.5)
+  })
+
+  test('extractConstraints handles null fields gracefully', async () => {
+    axios.post
+      .mockResolvedValueOnce({
+        data: { data: { gene: { gnomad_constraint: { pLI: 0.5, oe_mis: null, oe_mis_lower: null, oe_mis_upper: null, oe_lof: null, oe_lof_lower: null, oe_lof_upper: null, mis_z: null, lof_z: null } } } },
+      })
+      .mockResolvedValueOnce({ data: { data: { gene: null } } })
+
+    const result = await getGeneConstraints('PARTIAL')
+    expect(result.constraints_v4.pLI).toBe(0.5)
+    expect(result.constraints_v4.oe_mis_upper).toBe('N/A')
+    expect(result.constraints_v4.oe_lof).toBe('N/A')
+    expect(result.constraints_v4.lof_z).toBe('N/A')
+  })
+
   test('caches results', async () => {
     axios.post
       .mockResolvedValueOnce(mockGnomadResponse(0.99, 0.92, 0.15, 2.5))

--- a/tests/getGeneConstraints.test.js
+++ b/tests/getGeneConstraints.test.js
@@ -1,0 +1,37 @@
+const getGeneConstraints = require('../utils/getGeneConstraints')
+const { cacheClear } = require('../utils/cache')
+
+describe('getGeneConstraints', () => {
+  beforeEach(() => {
+    cacheClear()
+  })
+
+  test('returns constraint scores for a known gene', async () => {
+    const result = await getGeneConstraints('BRCA1')
+    expect(result).toBeDefined()
+    expect(result.constraints_v2).toBeDefined()
+    expect(result.constraints_v4).toBeDefined()
+    expect(typeof result.constraintsDelta).toBe('boolean')
+    // Check v4 has real data
+    expect(result.constraints_v4.pLI).not.toBe('N/A')
+    expect(typeof result.constraints_v4.pLI).toBe('number')
+    // New field
+    expect(result.gnomadUrl).toContain('gnomad.broadinstitute.org')
+  }, 30000)
+
+  test('returns N/A for unknown gene', async () => {
+    const result = await getGeneConstraints('XYZNOTAREALGENE123')
+    expect(result.constraints_v2.pLI).toBe('N/A')
+    expect(result.constraints_v4.pLI).toBe('N/A')
+    expect(result.constraintsDelta).toBe(false)
+  }, 30000)
+
+  test('caches results', async () => {
+    const result1 = await getGeneConstraints('TP53')
+    const start = Date.now()
+    const result2 = await getGeneConstraints('TP53')
+    const elapsed = Date.now() - start
+    expect(result2).toEqual(result1)
+    expect(elapsed).toBeLessThan(50)
+  }, 30000)
+})

--- a/tests/getGeneConstraints.test.js
+++ b/tests/getGeneConstraints.test.js
@@ -12,15 +12,8 @@ function mockGnomadResponse(pLI, oe_mis_upper, oe_lof_upper, mis_z) {
           gene_id: 'ENSG00000012048',
           symbol: 'BRCA1',
           gnomad_constraint: {
-            pLI: pLI,
-            oe_mis: 0.85,
-            oe_mis_lower: 0.80,
-            oe_mis_upper: oe_mis_upper,
-            oe_lof: 0.1,
-            oe_lof_lower: 0.05,
-            oe_lof_upper: oe_lof_upper,
-            mis_z: mis_z,
-            lof_z: 4.5,
+            pLI, oe_mis: 0.85, oe_mis_lower: 0.80, oe_mis_upper, oe_lof: 0.1,
+            oe_lof_lower: 0.05, oe_lof_upper, mis_z, lof_z: 4.5,
           },
         },
       },
@@ -36,30 +29,21 @@ describe('getGeneConstraints', () => {
 
   test('queries gnomAD GraphQL API for v2 and v4', async () => {
     axios.post
-      .mockResolvedValueOnce(mockGnomadResponse(0.99, 0.92, 0.15, 2.5)) // v4
-      .mockResolvedValueOnce(mockGnomadResponse(0.98, 0.90, 0.12, 2.3)) // v2
+      .mockResolvedValueOnce(mockGnomadResponse(0.99, 0.92, 0.15, 2.5))
+      .mockResolvedValueOnce(mockGnomadResponse(0.98, 0.90, 0.12, 2.3))
 
     const result = await getGeneConstraints('BRCA1')
 
     expect(result.constraints_v4.pLI).toBe(0.99)
-    expect(result.constraints_v4.oe_mis_upper).toBe(0.92)
-    expect(result.constraints_v4.oe_lof_upper).toBe(0.15)
-    expect(result.constraints_v4.mis_z).toBe(2.5)
-
     expect(result.constraints_v2.pLI).toBe(0.98)
-    expect(result.constraints_v2.oe_lof_upper).toBe(0.12)
-
-    expect(result.gnomadUrl).toBe('https://gnomad.broadinstitute.org/gene/BRCA1?dataset=gnomad_r4')
-
-    // Both queries sent in parallel
+    expect(result.gnomadUrl).toContain('BRCA1')
     expect(axios.post).toHaveBeenCalledTimes(2)
-    expect(axios.post.mock.calls[0][0]).toBe('https://gnomad.broadinstitute.org/api')
   })
 
-  test('detects significant delta between v2 and v4', async () => {
+  test('detects significant delta (pLI ratio > 1.5x)', async () => {
     axios.post
-      .mockResolvedValueOnce(mockGnomadResponse(0.99, 0.92, 0.15, 2.5)) // v4 high pLI
-      .mockResolvedValueOnce(mockGnomadResponse(0.30, 0.90, 0.12, 2.3)) // v2 low pLI (>1.5x diff)
+      .mockResolvedValueOnce(mockGnomadResponse(0.99, 0.92, 0.15, 2.5)) // v4 high
+      .mockResolvedValueOnce(mockGnomadResponse(0.30, 0.90, 0.12, 2.3)) // v2 low
 
     const result = await getGeneConstraints('GENE1')
     expect(result.constraintsDelta).toBe(true)
@@ -74,6 +58,24 @@ describe('getGeneConstraints', () => {
     expect(result.constraintsDelta).toBe(false)
   })
 
+  test('detects delta when one pLI is zero and the other is not', async () => {
+    axios.post
+      .mockResolvedValueOnce(mockGnomadResponse(0.0, 0.92, 0.15, 2.5))  // v4 pLI=0
+      .mockResolvedValueOnce(mockGnomadResponse(0.98, 0.90, 0.12, 2.3)) // v2 pLI=0.98
+
+    const result = await getGeneConstraints('GENE3')
+    expect(result.constraintsDelta).toBe(true) // 0 vs 0.98 = different
+  })
+
+  test('delta when one is N/A and the other is not', async () => {
+    axios.post
+      .mockResolvedValueOnce(mockGnomadResponse(0.99, 0.92, 0.15, 2.5)) // v4 has data
+      .mockResolvedValueOnce({ data: { data: { gene: null } } })          // v2 N/A
+
+    const result = await getGeneConstraints('GENE4')
+    expect(result.constraintsDelta).toBe(true) // N/A vs 0.99 = different
+  })
+
   test('returns N/A when gene not found in gnomAD', async () => {
     axios.post
       .mockResolvedValueOnce({ data: { data: { gene: null } } })
@@ -82,16 +84,14 @@ describe('getGeneConstraints', () => {
     const result = await getGeneConstraints('FAKEGENE')
     expect(result.constraints_v2.pLI).toBe('N/A')
     expect(result.constraints_v4.pLI).toBe('N/A')
-    expect(result.constraintsDelta).toBe(false)
+    expect(result.constraintsDelta).toBe(false) // Both N/A = no delta
   })
 
   test('returns fallback on API error', async () => {
     axios.post.mockRejectedValueOnce(new Error('timeout'))
-
     const result = await getGeneConstraints('BRCA1')
     expect(result.constraints_v2.pLI).toBe('N/A')
     expect(result.error).toBe('timeout')
-    expect(result.gnomadUrl).toContain('BRCA1')
   })
 
   test('caches results', async () => {
@@ -101,8 +101,7 @@ describe('getGeneConstraints', () => {
 
     const result1 = await getGeneConstraints('TP53')
     const result2 = await getGeneConstraints('TP53')
-
     expect(result2).toEqual(result1)
-    expect(axios.post).toHaveBeenCalledTimes(2) // Only first call
+    expect(axios.post).toHaveBeenCalledTimes(2)
   })
 })

--- a/tests/getMouseKO.test.js
+++ b/tests/getMouseKO.test.js
@@ -1,0 +1,59 @@
+const axios = require('axios')
+const getMouseKO = require('../utils/getMouseKO')
+const { cacheClear } = require('../utils/cache')
+
+jest.mock('axios')
+
+describe('getMouseKO', () => {
+  beforeEach(() => {
+    cacheClear()
+    jest.clearAllMocks()
+  })
+
+  test('groups phenotypes by category with capitalization', async () => {
+    axios.get.mockResolvedValue({
+      data: {
+        response: {
+          docs: [
+            { mp_term_name: 'increased body weight', top_level_mp_term_name: ['growth/size/body region'] },
+            { mp_term_name: 'decreased grip strength', top_level_mp_term_name: ['behavior/neurological'] },
+            { mp_term_name: 'abnormal coat color', top_level_mp_term_name: ['pigmentation'] },
+            { mp_term_name: 'increased body weight', top_level_mp_term_name: ['growth/size/body region'] }, // duplicate
+          ],
+        },
+      },
+    })
+
+    const result = await getMouseKO('MGI:104537')
+
+    expect(result.phenotypeCount).toBe(3) // Deduped
+    expect(result.categoryCount).toBe(3)
+    expect(result.mousePhenotypes.growth_size_body_region.names).toContain('Increased body weight')
+    expect(result.mousePhenotypes.behavior_neurological.names).toContain('Decreased grip strength')
+    expect(result.impcUrl).toBe('https://www.mousephenotype.org/data/genes/MGI:104537')
+  })
+
+  test('returns empty when no mgdId', async () => {
+    const result = await getMouseKO(null)
+    expect(result.mousePhenotypes).toEqual({})
+    expect(result.impcUrl).toBeNull()
+    expect(axios.get).not.toHaveBeenCalled()
+  })
+
+  test('returns fallback on API error', async () => {
+    axios.get.mockRejectedValue(new Error('IMPC down'))
+
+    const result = await getMouseKO('MGI:104537')
+    expect(result.phenotypeCount).toBe(0)
+    expect(result.error).toBe('IMPC down')
+    expect(result.impcUrl).toContain('MGI:104537')
+  })
+
+  test('caches results', async () => {
+    axios.get.mockResolvedValue({ data: { response: { docs: [] } } })
+
+    await getMouseKO('MGI:999')
+    await getMouseKO('MGI:999')
+    expect(axios.get).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/getPanelApps.test.js
+++ b/tests/getPanelApps.test.js
@@ -1,0 +1,57 @@
+const axios = require('axios')
+const getPanelApps = require('../utils/getPanelApps')
+const { cacheClear } = require('../utils/cache')
+
+jest.mock('axios')
+
+describe('getPanelApps', () => {
+  beforeEach(() => {
+    cacheClear()
+    jest.clearAllMocks()
+  })
+
+  test('fetches counts from UK and Australia', async () => {
+    axios.get
+      .mockResolvedValueOnce({ data: { count: 5 } })  // UK
+      .mockResolvedValueOnce({ data: { count: 2 } })  // Australia
+
+    const result = await getPanelApps('BRCA1')
+    expect(result.panelAppEnglandCount).toBe(5)
+    expect(result.panelAppAustraliaCount).toBe(2)
+    expect(result.panelAppEnglandError).toBeNull()
+    expect(result.panelAppAustraliaError).toBeNull()
+  })
+
+  test('falls back to staging URL for Australia', async () => {
+    axios.get
+      .mockResolvedValueOnce({ data: { count: 5 } })  // UK OK
+      .mockRejectedValueOnce(new Error('Australia down')) // Australia main fails
+      .mockResolvedValueOnce({ data: { count: 3 } })  // Australia staging OK
+
+    const result = await getPanelApps('TP53')
+    expect(result.panelAppEnglandCount).toBe(5)
+    expect(result.panelAppAustraliaCount).toBe(3)
+  })
+
+  test('reports errors per source independently', async () => {
+    axios.get
+      .mockRejectedValueOnce(new Error('UK down'))     // UK fails
+      .mockResolvedValueOnce({ data: { count: 2 } })   // Australia OK
+
+    const result = await getPanelApps('BRCA1')
+    expect(result.panelAppEnglandCount).toBeNull()
+    expect(result.panelAppEnglandError).toBe('PanelApp UK is currently unavailable')
+    expect(result.panelAppAustraliaCount).toBe(2)
+    expect(result.panelAppAustraliaError).toBeNull()
+  })
+
+  test('caches results', async () => {
+    axios.get
+      .mockResolvedValueOnce({ data: { count: 5 } })
+      .mockResolvedValueOnce({ data: { count: 2 } })
+
+    await getPanelApps('BRCA1')
+    await getPanelApps('BRCA1')
+    expect(axios.get).toHaveBeenCalledTimes(2) // Only first call
+  })
+})

--- a/tests/getPubMedData.test.js
+++ b/tests/getPubMedData.test.js
@@ -1,67 +1,147 @@
+const axios = require('axios')
 const getPubMedData = require('../utils/getPubMedData')
 const { cacheClear } = require('../utils/cache')
+
+jest.mock('axios')
+
+const MOCK_ESEARCH_RESPONSE = {
+  data: {
+    esearchresult: {
+      count: '42567',
+      idlist: ['36397405', '35950988', '33834176'],
+    },
+  },
+}
+
+const MOCK_EFETCH_XML = `<?xml version="1.0"?>
+<PubmedArticleSet>
+  <PubmedArticle>
+    <MedlineCitation>
+      <PMID>36397405</PMID>
+      <Article>
+        <ArticleTitle>BRCA2 gene mutation in cancer.</ArticleTitle>
+        <Abstract><AbstractText>BRCA2 is associated with hereditary breast cancers and other tumors.</AbstractText></Abstract>
+        <AuthorList>
+          <Author><LastName>Smith</LastName><Initials>JA</Initials></Author>
+          <Author><LastName>Doe</LastName><Initials>B</Initials></Author>
+        </AuthorList>
+        <Journal>
+          <Title>Cancer Research</Title>
+          <JournalIssue><PubDate><Year>2022</Year></PubDate></JournalIssue>
+        </Journal>
+      </Article>
+    </MedlineCitation>
+    <PubmedData>
+      <ArticleIdList>
+        <ArticleId IdType="doi">10.1234/test.2022</ArticleId>
+        <ArticleId IdType="pubmed">36397405</ArticleId>
+      </ArticleIdList>
+    </PubmedData>
+  </PubmedArticle>
+  <PubmedArticle>
+    <MedlineCitation>
+      <PMID>35950988</PMID>
+      <Article>
+        <ArticleTitle>Second article about BRCA.</ArticleTitle>
+        <Journal><Title>Nature</Title><JournalIssue><PubDate><Year>2023</Year></PubDate></JournalIssue></Journal>
+      </Article>
+    </MedlineCitation>
+    <PubmedData><ArticleIdList><ArticleId IdType="pubmed">35950988</ArticleId></ArticleIdList></PubmedData>
+  </PubmedArticle>
+  <PubmedArticle>
+    <MedlineCitation>
+      <PMID>33834176</PMID>
+      <Article>
+        <ArticleTitle>Third BRCA article.</ArticleTitle>
+        <Journal><Title>Cell</Title><JournalIssue><PubDate><Year>2021</Year></PubDate></JournalIssue></Journal>
+      </Article>
+    </MedlineCitation>
+    <PubmedData><ArticleIdList><ArticleId IdType="pubmed">33834176</ArticleId></ArticleIdList></PubmedData>
+  </PubmedArticle>
+</PubmedArticleSet>`
 
 describe('getPubMedData', () => {
   beforeEach(() => {
     cacheClear()
+    jest.clearAllMocks()
   })
 
-  test('returns correct shape for a known gene', async () => {
+  test('parses E-utilities response into articles with full metadata', async () => {
+    axios.get
+      .mockResolvedValueOnce(MOCK_ESEARCH_RESPONSE) // esearch
+      .mockResolvedValueOnce({ data: MOCK_EFETCH_XML }) // efetch
+
     const result = await getPubMedData('BRCA1', [])
-    expect(result).toBeDefined()
+
     expect(result.gene).toBe('BRCA1')
-    expect(typeof result.count).toBe('number')
-    expect(result.pubmedUrl).toContain('pubmed.ncbi.nlm.nih.gov')
-    expect(Array.isArray(result.articles)).toBe(true)
-    // Legacy keys always present
-    expect(result).toHaveProperty('firstArticleTitle')
-    expect(result).toHaveProperty('firstArticleUrl')
-    expect(Array.isArray(result.complArticles)).toBe(true)
+    expect(result.count).toBe(42567)
+    expect(result.articleCount).toBe(42567)
+    expect(result.pubmedUrl).toBe('https://pubmed.ncbi.nlm.nih.gov/?term=BRCA1')
 
-    // If API responded (no rate limit), should have articles
-    if (!result.error) {
-      expect(result.count).toBeGreaterThan(0)
-      expect(result.articles.length).toBeGreaterThan(0)
-      expect(result.articles[0]).toHaveProperty('pmid')
-      expect(result.articles[0]).toHaveProperty('title')
-      expect(result.articles[0]).toHaveProperty('authors')
-      expect(result.articles[0]).toHaveProperty('doi')
-      expect(result.firstArticleTitle).not.toBe('No articles found')
-      expect(result.firstArticleUrl).toContain('pubmed.ncbi.nlm.nih.gov')
-    }
-  }, 30000)
+    // Articles parsed correctly
+    expect(result.articles).toHaveLength(3)
+    expect(result.articles[0].pmid).toBe('36397405')
+    expect(result.articles[0].title).toBe('BRCA2 gene mutation in cancer.')
+    expect(result.articles[0].authors).toEqual(['Smith JA', 'Doe B'])
+    expect(result.articles[0].journal).toBe('Cancer Research')
+    expect(result.articles[0].year).toBe('2022')
+    expect(result.articles[0].doi).toBe('10.1234/test.2022')
+    expect(result.articles[0].abstract).toContain('BRCA2 is associated')
 
-  test('returns articles with phenotype refinement', async () => {
-    const result = await getPubMedData('TP53', ['cancer'])
-    expect(result).toBeDefined()
-    expect(result.gene).toBe('TP53')
-    if (!result.error) {
-      expect(result.count).toBeGreaterThan(0)
-      expect(result.articles.length).toBeGreaterThan(0)
-    }
-  }, 30000)
+    // Legacy keys for web app backward compat
+    expect(result.firstArticleTitle).toBe('BRCA2 gene mutation in cancer.')
+    expect(result.firstArticleUrl).toBe('https://pubmed.ncbi.nlm.nih.gov/36397405/')
+    expect(result.complArticles).toHaveLength(2)
+    expect(result.complArticles[0].title).toBe('Second article about BRCA.')
+  })
 
-  test('returns zero results for nonsense gene', async () => {
-    const result = await getPubMedData('XYZNOTAREALGENE123', [])
-    // Even on rate limit, shape is correct
-    expect(typeof result.count).toBe('number')
-    expect(Array.isArray(result.articles)).toBe(true)
-    if (!result.error) {
-      expect(result.count).toBe(0)
-      expect(result.articles).toEqual([])
-      expect(result.firstArticleTitle).toBe('No articles found')
-    }
-  }, 30000)
+  test('builds correct query with phenotypes', async () => {
+    axios.get
+      .mockResolvedValueOnce({
+        data: { esearchresult: { count: '0', idlist: [] } },
+      })
 
-  test('caches successful results', async () => {
+    await getPubMedData('TP53', ['cancer', 'Li-Fraumeni'])
+
+    const calledUrl = axios.get.mock.calls[0][0]
+    expect(calledUrl).toContain('(TP53%20AND%20cancer)%20OR%20(TP53%20AND%20Li-Fraumeni)')
+  })
+
+  test('returns empty results when no articles found', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: { esearchresult: { count: '0', idlist: [] } },
+    })
+
+    const result = await getPubMedData('XYZFAKE', [])
+
+    expect(result.count).toBe(0)
+    expect(result.articles).toEqual([])
+    expect(result.firstArticleTitle).toBe('No articles found')
+    expect(result.firstArticleUrl).toBeNull()
+  })
+
+  test('returns fallback on API error', async () => {
+    axios.get.mockRejectedValueOnce(new Error('Network error'))
+
+    const result = await getPubMedData('BRCA1', [])
+
+    expect(result.count).toBe(0)
+    expect(result.articles).toEqual([])
+    expect(result.error).toBe('Network error')
+    expect(result.gene).toBe('BRCA1')
+    expect(result.pubmedUrl).toContain('BRCA1')
+  })
+
+  test('caches results on second call', async () => {
+    axios.get
+      .mockResolvedValueOnce(MOCK_ESEARCH_RESPONSE)
+      .mockResolvedValueOnce({ data: MOCK_EFETCH_XML })
+
     const result1 = await getPubMedData('BRCA2', [])
-    // Only test caching if first call succeeded (not rate-limited)
-    if (!result1.error) {
-      const start = Date.now()
-      const result2 = await getPubMedData('BRCA2', [])
-      const elapsed = Date.now() - start
-      expect(result2).toEqual(result1)
-      expect(elapsed).toBeLessThan(50) // Cache hit should be near-instant
-    }
-  }, 30000)
+    const result2 = await getPubMedData('BRCA2', [])
+
+    expect(result2).toEqual(result1)
+    // axios.get should only be called for the first request (2 calls: esearch + efetch)
+    expect(axios.get).toHaveBeenCalledTimes(2)
+  })
 })

--- a/tests/getPubMedData.test.js
+++ b/tests/getPubMedData.test.js
@@ -155,6 +155,69 @@ describe('getPubMedData', () => {
     expect(result.error).toBe('Network error')
   })
 
+  test('handles article with no abstract, no authors, no journal, no year, no DOI', async () => {
+    const xml = `<PubmedArticleSet><PubmedArticle>
+      <MedlineCitation><PMID>555</PMID>
+        <Article><ArticleTitle>Bare article</ArticleTitle>
+          <Journal><JournalIssue><PubDate></PubDate></JournalIssue></Journal>
+        </Article>
+      </MedlineCitation>
+      <PubmedData><ArticleIdList><ArticleId IdType="pubmed">555</ArticleId></ArticleIdList></PubmedData>
+    </PubmedArticle></PubmedArticleSet>`
+
+    rateLimitedGet
+      .mockResolvedValueOnce({ data: { esearchresult: { count: '1', idlist: ['555'] } } })
+      .mockResolvedValueOnce({ data: xml })
+
+    const result = await getPubMedData('BARE', [])
+    const a = result.articles[0]
+    expect(a.pmid).toBe('555')
+    expect(a.title).toBe('Bare article')
+    expect(a.authors).toEqual([])
+    expect(a.journal).toBe('')
+    expect(a.year).toBe('')
+    expect(a.doi).toBe('')
+    expect(a.abstract).toBe('')
+  })
+
+  test('handles PMID as direct text (not object with _)', async () => {
+    const xml = `<PubmedArticleSet><PubmedArticle>
+      <MedlineCitation><PMID>444</PMID>
+        <Article><ArticleTitle>Direct PMID</ArticleTitle>
+          <Journal><Title>J</Title><JournalIssue><PubDate><Year>2024</Year></PubDate></JournalIssue></Journal>
+        </Article>
+      </MedlineCitation>
+      <PubmedData><ArticleIdList><ArticleId IdType="pubmed">444</ArticleId></ArticleIdList></PubmedData>
+    </PubmedArticle></PubmedArticleSet>`
+
+    rateLimitedGet
+      .mockResolvedValueOnce({ data: { esearchresult: { count: '1', idlist: ['444'] } } })
+      .mockResolvedValueOnce({ data: xml })
+
+    const result = await getPubMedData('PMIDTEST', [])
+    expect(result.articles[0].pmid).toBe('444')
+  })
+
+  test('handles efetch returning no PubmedArticle', async () => {
+    rateLimitedGet
+      .mockResolvedValueOnce({ data: { esearchresult: { count: '1', idlist: ['333'] } } })
+      .mockResolvedValueOnce({ data: '<PubmedArticleSet></PubmedArticleSet>' })
+
+    const result = await getPubMedData('EMPTY_FETCH', [])
+    expect(result.articles).toEqual([])
+    expect(result.count).toBe(1)
+    expect(result.firstArticleTitle).toBe('No articles found')
+  })
+
+  test('handles NaN count from esearch', async () => {
+    rateLimitedGet.mockResolvedValueOnce({
+      data: { esearchresult: { count: 'not-a-number', idlist: [] } },
+    })
+
+    const result = await getPubMedData('NANCOUNT', [])
+    expect(result.count).toBe(0)
+  })
+
   test('caches results on second call', async () => {
     rateLimitedGet
       .mockResolvedValueOnce({ data: { esearchresult: { count: '10', idlist: ['111'] } } })

--- a/tests/getPubMedData.test.js
+++ b/tests/getPubMedData.test.js
@@ -1,0 +1,67 @@
+const getPubMedData = require('../utils/getPubMedData')
+const { cacheClear } = require('../utils/cache')
+
+describe('getPubMedData', () => {
+  beforeEach(() => {
+    cacheClear()
+  })
+
+  test('returns correct shape for a known gene', async () => {
+    const result = await getPubMedData('BRCA1', [])
+    expect(result).toBeDefined()
+    expect(result.gene).toBe('BRCA1')
+    expect(typeof result.count).toBe('number')
+    expect(result.pubmedUrl).toContain('pubmed.ncbi.nlm.nih.gov')
+    expect(Array.isArray(result.articles)).toBe(true)
+    // Legacy keys always present
+    expect(result).toHaveProperty('firstArticleTitle')
+    expect(result).toHaveProperty('firstArticleUrl')
+    expect(Array.isArray(result.complArticles)).toBe(true)
+
+    // If API responded (no rate limit), should have articles
+    if (!result.error) {
+      expect(result.count).toBeGreaterThan(0)
+      expect(result.articles.length).toBeGreaterThan(0)
+      expect(result.articles[0]).toHaveProperty('pmid')
+      expect(result.articles[0]).toHaveProperty('title')
+      expect(result.articles[0]).toHaveProperty('authors')
+      expect(result.articles[0]).toHaveProperty('doi')
+      expect(result.firstArticleTitle).not.toBe('No articles found')
+      expect(result.firstArticleUrl).toContain('pubmed.ncbi.nlm.nih.gov')
+    }
+  }, 30000)
+
+  test('returns articles with phenotype refinement', async () => {
+    const result = await getPubMedData('TP53', ['cancer'])
+    expect(result).toBeDefined()
+    expect(result.gene).toBe('TP53')
+    if (!result.error) {
+      expect(result.count).toBeGreaterThan(0)
+      expect(result.articles.length).toBeGreaterThan(0)
+    }
+  }, 30000)
+
+  test('returns zero results for nonsense gene', async () => {
+    const result = await getPubMedData('XYZNOTAREALGENE123', [])
+    // Even on rate limit, shape is correct
+    expect(typeof result.count).toBe('number')
+    expect(Array.isArray(result.articles)).toBe(true)
+    if (!result.error) {
+      expect(result.count).toBe(0)
+      expect(result.articles).toEqual([])
+      expect(result.firstArticleTitle).toBe('No articles found')
+    }
+  }, 30000)
+
+  test('caches successful results', async () => {
+    const result1 = await getPubMedData('BRCA2', [])
+    // Only test caching if first call succeeded (not rate-limited)
+    if (!result1.error) {
+      const start = Date.now()
+      const result2 = await getPubMedData('BRCA2', [])
+      const elapsed = Date.now() - start
+      expect(result2).toEqual(result1)
+      expect(elapsed).toBeLessThan(50) // Cache hit should be near-instant
+    }
+  }, 30000)
+})

--- a/tests/getPubMedData.test.js
+++ b/tests/getPubMedData.test.js
@@ -1,8 +1,12 @@
-const axios = require('axios')
 const getPubMedData = require('../utils/getPubMedData')
 const { cacheClear } = require('../utils/cache')
+const { rateLimitedGet } = require('../utils/rateLimiter')
 
-jest.mock('axios')
+// Mock rateLimitedGet — rate limiter is tested in rateLimiter.test.js
+jest.mock('../utils/rateLimiter', () => ({
+  rateLimitedGet: jest.fn(),
+  resetLimiter: jest.fn(),
+}))
 
 const MOCK_ESEARCH_RESPONSE = {
   data: {
@@ -67,7 +71,7 @@ describe('getPubMedData', () => {
   })
 
   test('parses E-utilities response into articles with full metadata', async () => {
-    axios.get
+    rateLimitedGet
       .mockResolvedValueOnce(MOCK_ESEARCH_RESPONSE) // esearch
       .mockResolvedValueOnce({ data: MOCK_EFETCH_XML }) // efetch
 
@@ -78,7 +82,6 @@ describe('getPubMedData', () => {
     expect(result.articleCount).toBe(42567)
     expect(result.pubmedUrl).toBe('https://pubmed.ncbi.nlm.nih.gov/?term=BRCA1')
 
-    // Articles parsed correctly
     expect(result.articles).toHaveLength(3)
     expect(result.articles[0].pmid).toBe('36397405')
     expect(result.articles[0].title).toBe('BRCA2 gene mutation in cancer.')
@@ -88,27 +91,25 @@ describe('getPubMedData', () => {
     expect(result.articles[0].doi).toBe('10.1234/test.2022')
     expect(result.articles[0].abstract).toContain('BRCA2 is associated')
 
-    // Legacy keys for web app backward compat
+    // Legacy keys
     expect(result.firstArticleTitle).toBe('BRCA2 gene mutation in cancer.')
     expect(result.firstArticleUrl).toBe('https://pubmed.ncbi.nlm.nih.gov/36397405/')
     expect(result.complArticles).toHaveLength(2)
-    expect(result.complArticles[0].title).toBe('Second article about BRCA.')
   })
 
   test('builds correct query with phenotypes', async () => {
-    axios.get
-      .mockResolvedValueOnce({
-        data: { esearchresult: { count: '0', idlist: [] } },
-      })
+    rateLimitedGet.mockResolvedValueOnce({
+      data: { esearchresult: { count: '0', idlist: [] } },
+    })
 
     await getPubMedData('TP53', ['cancer', 'Li-Fraumeni'])
 
-    const calledUrl = axios.get.mock.calls[0][0]
+    const calledUrl = rateLimitedGet.mock.calls[0][1]
     expect(calledUrl).toContain('(TP53%20AND%20cancer)%20OR%20(TP53%20AND%20Li-Fraumeni)')
   })
 
   test('returns empty results when no articles found', async () => {
-    axios.get.mockResolvedValueOnce({
+    rateLimitedGet.mockResolvedValueOnce({
       data: { esearchresult: { count: '0', idlist: [] } },
     })
 
@@ -121,7 +122,7 @@ describe('getPubMedData', () => {
   })
 
   test('returns fallback on API error', async () => {
-    axios.get.mockRejectedValueOnce(new Error('Network error'))
+    rateLimitedGet.mockRejectedValue(new Error('Network error'))
 
     const result = await getPubMedData('BRCA1', [])
 
@@ -129,11 +130,10 @@ describe('getPubMedData', () => {
     expect(result.articles).toEqual([])
     expect(result.error).toBe('Network error')
     expect(result.gene).toBe('BRCA1')
-    expect(result.pubmedUrl).toContain('BRCA1')
   })
 
   test('caches results on second call', async () => {
-    axios.get
+    rateLimitedGet
       .mockResolvedValueOnce(MOCK_ESEARCH_RESPONSE)
       .mockResolvedValueOnce({ data: MOCK_EFETCH_XML })
 
@@ -141,7 +141,6 @@ describe('getPubMedData', () => {
     const result2 = await getPubMedData('BRCA2', [])
 
     expect(result2).toEqual(result1)
-    // axios.get should only be called for the first request (2 calls: esearch + efetch)
-    expect(axios.get).toHaveBeenCalledTimes(2)
+    expect(rateLimitedGet).toHaveBeenCalledTimes(2) // esearch + efetch, once only
   })
 })

--- a/tests/getPubMedData.test.js
+++ b/tests/getPubMedData.test.js
@@ -2,67 +2,30 @@ const getPubMedData = require('../utils/getPubMedData')
 const { cacheClear } = require('../utils/cache')
 const { rateLimitedGet } = require('../utils/rateLimiter')
 
-// Mock rateLimitedGet — rate limiter is tested in rateLimiter.test.js
 jest.mock('../utils/rateLimiter', () => ({
   rateLimitedGet: jest.fn(),
   resetLimiter: jest.fn(),
 }))
 
-const MOCK_ESEARCH_RESPONSE = {
-  data: {
-    esearchresult: {
-      count: '42567',
-      idlist: ['36397405', '35950988', '33834176'],
-    },
-  },
+function efetchXml(articles) {
+  const items = articles.map((a) => `
+    <PubmedArticle>
+      <MedlineCitation>
+        <PMID>${a.pmid}</PMID>
+        <Article>
+          <ArticleTitle>${a.title}</ArticleTitle>
+          ${a.abstract !== undefined ? `<Abstract><AbstractText>${typeof a.abstract === 'string' ? a.abstract : JSON.stringify(a.abstract)}</AbstractText></Abstract>` : ''}
+          ${a.authors ? `<AuthorList>${a.authors.map((au) => `<Author><LastName>${au.last}</LastName><Initials>${au.init}</Initials></Author>`).join('')}</AuthorList>` : ''}
+          <Journal><Title>${a.journal || ''}</Title><JournalIssue><PubDate><Year>${a.year || ''}</Year></PubDate></JournalIssue></Journal>
+        </Article>
+      </MedlineCitation>
+      <PubmedData><ArticleIdList>
+        ${a.doi ? `<ArticleId IdType="doi">${a.doi}</ArticleId>` : ''}
+        <ArticleId IdType="pubmed">${a.pmid}</ArticleId>
+      </ArticleIdList></PubmedData>
+    </PubmedArticle>`)
+  return `<PubmedArticleSet>${items.join('')}</PubmedArticleSet>`
 }
-
-const MOCK_EFETCH_XML = `<?xml version="1.0"?>
-<PubmedArticleSet>
-  <PubmedArticle>
-    <MedlineCitation>
-      <PMID>36397405</PMID>
-      <Article>
-        <ArticleTitle>BRCA2 gene mutation in cancer.</ArticleTitle>
-        <Abstract><AbstractText>BRCA2 is associated with hereditary breast cancers and other tumors.</AbstractText></Abstract>
-        <AuthorList>
-          <Author><LastName>Smith</LastName><Initials>JA</Initials></Author>
-          <Author><LastName>Doe</LastName><Initials>B</Initials></Author>
-        </AuthorList>
-        <Journal>
-          <Title>Cancer Research</Title>
-          <JournalIssue><PubDate><Year>2022</Year></PubDate></JournalIssue>
-        </Journal>
-      </Article>
-    </MedlineCitation>
-    <PubmedData>
-      <ArticleIdList>
-        <ArticleId IdType="doi">10.1234/test.2022</ArticleId>
-        <ArticleId IdType="pubmed">36397405</ArticleId>
-      </ArticleIdList>
-    </PubmedData>
-  </PubmedArticle>
-  <PubmedArticle>
-    <MedlineCitation>
-      <PMID>35950988</PMID>
-      <Article>
-        <ArticleTitle>Second article about BRCA.</ArticleTitle>
-        <Journal><Title>Nature</Title><JournalIssue><PubDate><Year>2023</Year></PubDate></JournalIssue></Journal>
-      </Article>
-    </MedlineCitation>
-    <PubmedData><ArticleIdList><ArticleId IdType="pubmed">35950988</ArticleId></ArticleIdList></PubmedData>
-  </PubmedArticle>
-  <PubmedArticle>
-    <MedlineCitation>
-      <PMID>33834176</PMID>
-      <Article>
-        <ArticleTitle>Third BRCA article.</ArticleTitle>
-        <Journal><Title>Cell</Title><JournalIssue><PubDate><Year>2021</Year></PubDate></JournalIssue></Journal>
-      </Article>
-    </MedlineCitation>
-    <PubmedData><ArticleIdList><ArticleId IdType="pubmed">33834176</ArticleId></ArticleIdList></PubmedData>
-  </PubmedArticle>
-</PubmedArticleSet>`
 
 describe('getPubMedData', () => {
   beforeEach(() => {
@@ -72,75 +35,134 @@ describe('getPubMedData', () => {
 
   test('parses E-utilities response into articles with full metadata', async () => {
     rateLimitedGet
-      .mockResolvedValueOnce(MOCK_ESEARCH_RESPONSE) // esearch
-      .mockResolvedValueOnce({ data: MOCK_EFETCH_XML }) // efetch
+      .mockResolvedValueOnce({ data: { esearchresult: { count: '42567', idlist: ['111', '222', '333'] } } })
+      .mockResolvedValueOnce({
+        data: efetchXml([
+          { pmid: '111', title: 'BRCA2 gene mutation in cancer.', abstract: 'BRCA2 is associated with hereditary breast cancers.', authors: [{ last: 'Smith', init: 'JA' }, { last: 'Doe', init: 'B' }], journal: 'Cancer Research', year: '2022', doi: '10.1234/test' },
+          { pmid: '222', title: 'Second article.', journal: 'Nature', year: '2023' },
+          { pmid: '333', title: 'Third article.', journal: 'Cell', year: '2021' },
+        ]),
+      })
 
     const result = await getPubMedData('BRCA1', [])
 
     expect(result.gene).toBe('BRCA1')
     expect(result.count).toBe(42567)
-    expect(result.articleCount).toBe(42567)
-    expect(result.pubmedUrl).toBe('https://pubmed.ncbi.nlm.nih.gov/?term=BRCA1')
-
     expect(result.articles).toHaveLength(3)
-    expect(result.articles[0].pmid).toBe('36397405')
+    expect(result.articles[0].pmid).toBe('111')
     expect(result.articles[0].title).toBe('BRCA2 gene mutation in cancer.')
     expect(result.articles[0].authors).toEqual(['Smith JA', 'Doe B'])
-    expect(result.articles[0].journal).toBe('Cancer Research')
-    expect(result.articles[0].year).toBe('2022')
-    expect(result.articles[0].doi).toBe('10.1234/test.2022')
+    expect(result.articles[0].doi).toBe('10.1234/test')
     expect(result.articles[0].abstract).toContain('BRCA2 is associated')
-
     // Legacy keys
     expect(result.firstArticleTitle).toBe('BRCA2 gene mutation in cancer.')
-    expect(result.firstArticleUrl).toBe('https://pubmed.ncbi.nlm.nih.gov/36397405/')
+    expect(result.firstArticleUrl).toBe('https://pubmed.ncbi.nlm.nih.gov/111/')
     expect(result.complArticles).toHaveLength(2)
   })
 
+  test('handles abstract as structured XML object (not string)', async () => {
+    // Some PubMed articles return AbstractText as an object with _
+    const xml = `<PubmedArticleSet><PubmedArticle>
+      <MedlineCitation><PMID>999</PMID>
+        <Article><ArticleTitle>Test</ArticleTitle>
+          <Abstract><AbstractText Label="BACKGROUND">Background text here.</AbstractText></Abstract>
+          <Journal><Title>J</Title><JournalIssue><PubDate><Year>2024</Year></PubDate></JournalIssue></Journal>
+        </Article>
+      </MedlineCitation>
+      <PubmedData><ArticleIdList><ArticleId IdType="pubmed">999</ArticleId></ArticleIdList></PubmedData>
+    </PubmedArticle></PubmedArticleSet>`
+
+    rateLimitedGet
+      .mockResolvedValueOnce({ data: { esearchresult: { count: '1', idlist: ['999'] } } })
+      .mockResolvedValueOnce({ data: xml })
+
+    const result = await getPubMedData('TEST', [])
+    expect(result.articles[0].abstract).toContain('Background text here')
+  })
+
+  test('handles abstract as array of sections', async () => {
+    const xml = `<PubmedArticleSet><PubmedArticle>
+      <MedlineCitation><PMID>888</PMID>
+        <Article><ArticleTitle>Multi-section abstract</ArticleTitle>
+          <Abstract>
+            <AbstractText Label="BACKGROUND">Part one.</AbstractText>
+            <AbstractText Label="METHODS">Part two.</AbstractText>
+          </Abstract>
+          <Journal><Title>J</Title><JournalIssue><PubDate><Year>2024</Year></PubDate></JournalIssue></Journal>
+        </Article>
+      </MedlineCitation>
+      <PubmedData><ArticleIdList><ArticleId IdType="pubmed">888</ArticleId></ArticleIdList></PubmedData>
+    </PubmedArticle></PubmedArticleSet>`
+
+    rateLimitedGet
+      .mockResolvedValueOnce({ data: { esearchresult: { count: '1', idlist: ['888'] } } })
+      .mockResolvedValueOnce({ data: xml })
+
+    const result = await getPubMedData('TEST2', [])
+    expect(result.articles[0].abstract).toContain('Part one')
+    expect(result.articles[0].abstract).toContain('Part two')
+  })
+
+  test('handles article title as object (XML with attributes)', async () => {
+    const xml = `<PubmedArticleSet><PubmedArticle>
+      <MedlineCitation><PMID>777</PMID>
+        <Article><ArticleTitle><i>Italic</i> title here.</ArticleTitle>
+          <Journal><Title>J</Title><JournalIssue><PubDate><Year>2024</Year></PubDate></JournalIssue></Journal>
+        </Article>
+      </MedlineCitation>
+      <PubmedData><ArticleIdList><ArticleId IdType="pubmed">777</ArticleId></ArticleIdList></PubmedData>
+    </PubmedArticle></PubmedArticleSet>`
+
+    rateLimitedGet
+      .mockResolvedValueOnce({ data: { esearchresult: { count: '1', idlist: ['777'] } } })
+      .mockResolvedValueOnce({ data: xml })
+
+    const result = await getPubMedData('TEST3', [])
+    expect(result.articles[0].title).toBeTruthy() // Should not crash on object title
+  })
+
+  test('handles more than 5 authors (truncates with et al.)', async () => {
+    const authors = Array.from({ length: 8 }, (_, i) => ({ last: `Author${i}`, init: 'X' }))
+    rateLimitedGet
+      .mockResolvedValueOnce({ data: { esearchresult: { count: '1', idlist: ['666'] } } })
+      .mockResolvedValueOnce({ data: efetchXml([{ pmid: '666', title: 'Many authors', authors, journal: 'J', year: '2024' }]) })
+
+    const result = await getPubMedData('TEST4', [])
+    expect(result.articles[0].authors).toHaveLength(6) // 5 + 'et al.'
+    expect(result.articles[0].authors[5]).toBe('et al.')
+  })
+
   test('builds correct query with phenotypes', async () => {
-    rateLimitedGet.mockResolvedValueOnce({
-      data: { esearchresult: { count: '0', idlist: [] } },
-    })
-
+    rateLimitedGet.mockResolvedValueOnce({ data: { esearchresult: { count: '0', idlist: [] } } })
     await getPubMedData('TP53', ['cancer', 'Li-Fraumeni'])
-
     const calledUrl = rateLimitedGet.mock.calls[0][1]
     expect(calledUrl).toContain('(TP53%20AND%20cancer)%20OR%20(TP53%20AND%20Li-Fraumeni)')
   })
 
   test('returns empty results when no articles found', async () => {
-    rateLimitedGet.mockResolvedValueOnce({
-      data: { esearchresult: { count: '0', idlist: [] } },
-    })
-
+    rateLimitedGet.mockResolvedValueOnce({ data: { esearchresult: { count: '0', idlist: [] } } })
     const result = await getPubMedData('XYZFAKE', [])
-
     expect(result.count).toBe(0)
     expect(result.articles).toEqual([])
     expect(result.firstArticleTitle).toBe('No articles found')
-    expect(result.firstArticleUrl).toBeNull()
   })
 
   test('returns fallback on API error', async () => {
     rateLimitedGet.mockRejectedValue(new Error('Network error'))
-
     const result = await getPubMedData('BRCA1', [])
-
     expect(result.count).toBe(0)
     expect(result.articles).toEqual([])
     expect(result.error).toBe('Network error')
-    expect(result.gene).toBe('BRCA1')
   })
 
   test('caches results on second call', async () => {
     rateLimitedGet
-      .mockResolvedValueOnce(MOCK_ESEARCH_RESPONSE)
-      .mockResolvedValueOnce({ data: MOCK_EFETCH_XML })
+      .mockResolvedValueOnce({ data: { esearchresult: { count: '10', idlist: ['111'] } } })
+      .mockResolvedValueOnce({ data: efetchXml([{ pmid: '111', title: 'Test', journal: 'J', year: '2024' }]) })
 
     const result1 = await getPubMedData('BRCA2', [])
     const result2 = await getPubMedData('BRCA2', [])
-
     expect(result2).toEqual(result1)
-    expect(rateLimitedGet).toHaveBeenCalledTimes(2) // esearch + efetch, once only
+    expect(rateLimitedGet).toHaveBeenCalledTimes(2)
   })
 })

--- a/tests/getUniProtFunction.test.js
+++ b/tests/getUniProtFunction.test.js
@@ -79,6 +79,32 @@ describe('getUniProtFunction', () => {
     expect(result.uniprotUrl).toContain('P38398')
   })
 
+  test('handles keywords download failure gracefully', async () => {
+    // Need a fresh module to reset the cached keywordsData singleton
+    jest.resetModules()
+    const freshAxios = require('axios')
+    const freshGetUniProt = require('../utils/getUniProtFunction')
+    const freshCache = require('../utils/cache')
+    freshCache.cacheClear()
+
+    jest.spyOn(freshAxios, 'get').mockImplementation((url) => {
+      if (url.includes('ebi.ac.uk/proteins')) {
+        return Promise.resolve({
+          data: {
+            comments: [{ type: 'FUNCTION', text: [{ value: 'Some function' }] }],
+            keywords: [{ value: 'Apoptosis' }],
+          },
+        })
+      }
+      if (url.includes('ftp.uniprot.org')) return Promise.reject(new Error('FTP down'))
+      return Promise.reject(new Error(`Unmocked: ${url}`))
+    })
+
+    const result = await freshGetUniProt('P99999')
+    expect(result.geneFunction).toBe('Some function')
+    expect(result.bioProcessKeywords).toEqual([]) // Can't filter without keywords data
+  })
+
   test('caches results', async () => {
     axios.get.mockImplementation((url) => {
       if (url.includes('ebi.ac.uk/proteins')) {

--- a/tests/getUniProtFunction.test.js
+++ b/tests/getUniProtFunction.test.js
@@ -1,0 +1,96 @@
+const axios = require('axios')
+const getUniProtFunction = require('../utils/getUniProtFunction')
+const { cacheClear } = require('../utils/cache')
+
+jest.mock('axios')
+
+const KEYWORDS_TXT = `ID   Apoptosis
+AC   KW-0053
+DE   Protein involved in apoptosis.
+CA   Biological process.
+//
+ID   Kinase
+AC   KW-0418
+DE   Enzyme that catalyzes phosphorylation.
+CA   Molecular function.
+//`
+
+describe('getUniProtFunction', () => {
+  beforeEach(() => {
+    cacheClear()
+    jest.clearAllMocks()
+  })
+
+  test('parses protein function and filters biological process keywords', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('ebi.ac.uk/proteins')) {
+        return Promise.resolve({
+          data: {
+            comments: [{ type: 'FUNCTION', text: [{ value: 'E3 ubiquitin-protein ligase involved in DNA repair.' }] }],
+            keywords: [{ value: 'Apoptosis' }, { value: 'Kinase' }],
+          },
+        })
+      }
+      if (url.includes('ftp.uniprot.org')) return Promise.resolve({ data: KEYWORDS_TXT })
+      return Promise.reject(new Error(`Unmocked: ${url}`))
+    })
+
+    const result = await getUniProtFunction('P38398')
+
+    expect(result.geneFunction).toBe('E3 ubiquitin-protein ligase involved in DNA repair.')
+    expect(result.bioProcessKeywords).toEqual(['Apoptosis']) // Kinase is molecular function, filtered out
+    expect(result.bioProcessKeywordsOnly).toEqual(['Apoptosis']) // Legacy key
+    expect(result.uniprotUrl).toBe('https://www.uniprot.org/uniprotkb/P38398/entry')
+    expect(result.urlAccession).toBe(result.uniprotUrl) // Legacy key
+  })
+
+  test('truncates long function text at 500 chars', async () => {
+    const longText = 'A'.repeat(600)
+    axios.get.mockImplementation((url) => {
+      if (url.includes('ebi.ac.uk/proteins')) {
+        return Promise.resolve({
+          data: {
+            comments: [{ type: 'FUNCTION', text: [{ value: longText }] }],
+            keywords: [],
+          },
+        })
+      }
+      if (url.includes('ftp.uniprot.org')) return Promise.resolve({ data: '' })
+      return Promise.reject(new Error(`Unmocked: ${url}`))
+    })
+
+    const result = await getUniProtFunction('P38398')
+    expect(result.geneFunction.length).toBe(503) // 500 + '...'
+  })
+
+  test('returns null fields when no uniprotId provided', async () => {
+    const result = await getUniProtFunction(null)
+    expect(result.geneFunction).toBeNull()
+    expect(result.bioProcessKeywords).toEqual([])
+    expect(axios.get).not.toHaveBeenCalled()
+  })
+
+  test('returns fallback on API error', async () => {
+    axios.get.mockRejectedValue(new Error('timeout'))
+
+    const result = await getUniProtFunction('P38398')
+    expect(result.geneFunction).toBeNull()
+    expect(result.error).toBe('timeout')
+    expect(result.uniprotUrl).toContain('P38398')
+  })
+
+  test('caches results', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('ebi.ac.uk/proteins')) {
+        return Promise.resolve({ data: { comments: [], keywords: [] } })
+      }
+      if (url.includes('ftp.uniprot.org')) return Promise.resolve({ data: '' })
+      return Promise.reject(new Error(`Unmocked: ${url}`))
+    })
+
+    await getUniProtFunction('Q12345')
+    await getUniProtFunction('Q12345')
+    const proteinCalls = axios.get.mock.calls.filter((c) => c[0].includes('ebi.ac.uk/proteins'))
+    expect(proteinCalls).toHaveLength(1)
+  })
+})

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1,14 +1,13 @@
 /**
  * Integration tests — hit real APIs with well-known genes.
- *
- * These are slow (30-120s per test) and depend on external services.
  * Run separately: npm run test:integration
  *
- * They verify that the full pipeline produces correct, non-trivial results
- * for BRCA1 and TP53 — two of the most studied genes in genomics.
+ * These MUST pass unconditionally. No skipping on error.
+ * If a source returns an error, the test fails — that means
+ * our retry logic or timeouts need fixing, not the test.
  */
 
-const { analyzeGenesStructured } = require('../services/dataservice')
+const { analyzeGenesStructured, validateGene, searchLiterature } = require('../services/dataservice')
 const { cacheClear } = require('../utils/cache')
 const { resetLimiter } = require('../utils/rateLimiter')
 
@@ -17,7 +16,7 @@ beforeAll(() => {
   resetLimiter()
 })
 
-describe('BRCA1 full analysis (real APIs)', () => {
+describe('BRCA1 full analysis', () => {
   let result
 
   beforeAll(async () => {
@@ -37,116 +36,74 @@ describe('BRCA1 full analysis (real APIs)', () => {
     expect(result.geneInfo.omimId).toBe('113705')
   })
 
-  test('ClinGen validity is Definitive for BRCA1', () => {
+  test('ClinGen validity is Definitive', () => {
     expect(result.geneInfo.geneValidity).toBe('Definitive')
   })
 
   test('PubMed returns articles with metadata', () => {
     const pubmed = result.sources.pubmed
-    if (pubmed.error) {
-      console.warn(`PubMed was rate-limited: ${pubmed.error}`)
-      return
-    }
+    expect(pubmed.error).toBeUndefined()
     expect(pubmed.articleCount).toBeGreaterThan(10000)
     expect(pubmed.articles.length).toBeGreaterThan(0)
     expect(pubmed.articles.length).toBeLessThanOrEqual(5)
 
     const article = pubmed.articles[0]
     expect(article.pmid).toMatch(/^\d+$/)
-    expect(article.title).toBeTruthy()
     expect(article.title.length).toBeGreaterThan(5)
     expect(article.journal).toBeTruthy()
     expect(article.year).toMatch(/^\d{4}$/)
-    expect(pubmed.pubmedUrl).toContain('pubmed.ncbi.nlm.nih.gov')
   })
 
-  test('ClinVar returns non-trivial pathogenic variant counts', () => {
+  test('ClinVar returns pathogenic variant counts', () => {
     const clinvar = result.sources.clinvar
-    if (clinvar.error) {
-      console.warn(`ClinVar was rate-limited: ${clinvar.error}`)
-      return
-    }
+    expect(clinvar.error).toBeUndefined()
     expect(clinvar.totalPathogenic).toBeGreaterThan(100)
     expect(typeof clinvar.lofVariants).toBe('number')
     expect(typeof clinvar.missenseVariants).toBe('number')
     expect(clinvar.clinvarUrl).toContain('BRCA1')
   })
 
-  test('gnomAD returns constraint scores for both genome builds', () => {
+  test('gnomAD returns constraint scores', () => {
     const constraints = result.sources.constraints
-    if (constraints.error) {
-      console.warn(`gnomAD was unavailable: ${constraints.error}`)
-      return
-    }
-    // BRCA1 is highly constrained — pLI should be near 0 (tolerant of LoF)
-    // or near 1 depending on the version. Just check it's a real number.
+    expect(constraints.error).toBeUndefined()
     expect(typeof constraints.constraints_v4.pLI).toBe('number')
     expect(typeof constraints.constraints_v2.pLI).toBe('number')
     expect(typeof constraints.constraints_v4.oe_lof_upper).toBe('number')
-    expect(typeof constraints.constraints_v4.mis_z).toBe('number')
     expect(constraints.gnomadUrl).toContain('BRCA1')
   })
 
-  test('UniProt returns protein function', () => {
+  test('UniProt returns protein function related to DNA repair', () => {
     const uniprot = result.sources.uniprot
-    if (uniprot.error) {
-      console.warn(`UniProt was unavailable: ${uniprot.error}`)
-      return
-    }
+    expect(uniprot.error).toBeUndefined()
     expect(uniprot.geneFunction).toBeTruthy()
     expect(uniprot.geneFunction.length).toBeGreaterThan(20)
-    // BRCA1 is involved in DNA repair
     expect(uniprot.geneFunction.toLowerCase()).toMatch(/dna|repair|ubiquitin|tumor/i)
     expect(uniprot.uniprotUrl).toContain('uniprot.org')
   })
 
-  test('IMPC returns mouse phenotypes', () => {
-    const mouseKO = result.sources.mouseKO
-    if (mouseKO.error) {
-      console.warn(`IMPC was unavailable: ${mouseKO.error}`)
-      return
-    }
-    // BRCA1 knockout mice have phenotypes
-    if (mouseKO.phenotypeCount > 0) {
-      expect(Object.keys(mouseKO.mousePhenotypes).length).toBeGreaterThan(0)
-      expect(mouseKO.impcUrl).toContain('mousephenotype.org')
-    }
-  })
-
   test('PanelApp returns panel counts', () => {
     const panelApps = result.sources.panelApps
-    // At least UK should respond
-    if (panelApps.panelAppEnglandCount !== null) {
-      expect(typeof panelApps.panelAppEnglandCount).toBe('number')
-    }
+    expect(panelApps.panelAppEnglandError).toBeNull()
+    expect(typeof panelApps.panelAppEnglandCount).toBe('number')
   })
 
-  test('OMIM returns disease associations', () => {
+  test('OMIM returns breast/ovarian cancer associations', () => {
     const omim = result.sources.omim
-    if (omim.error) {
-      console.warn(`OMIM was unavailable: ${omim.error}`)
-      return
-    }
-    // BRCA1 is associated with breast/ovarian cancer in OMIM
-    if (omim.mim.length > 0) {
-      const allDescriptions = omim.mim.join(' ').toLowerCase()
-      expect(allDescriptions).toMatch(/breast|ovarian|cancer|carcinoma/i)
-    }
+    expect(omim.error).toBeUndefined()
+    expect(omim.mim.length).toBeGreaterThan(0)
+    const allDescriptions = omim.mim.join(' ').toLowerCase()
+    expect(allDescriptions).toMatch(/breast|ovarian|cancer|carcinoma/i)
   })
 
-  test('sourceErrors is an array (may be empty if all sources responded)', () => {
-    expect(Array.isArray(result.sourceErrors)).toBe(true)
-    if (result.sourceErrors.length > 0) {
-      console.warn('Some sources had errors:', result.sourceErrors.map((e) => `${e.source}: ${e.error}`).join(', '))
-    }
+  test('no source errors', () => {
+    expect(result.sourceErrors).toEqual([])
   })
 })
 
-describe('TP53 full analysis (real APIs)', () => {
+describe('TP53 full analysis', () => {
   let result
 
   beforeAll(async () => {
-    // Use the cache from BRCA1 run for shared resources (ClinGen, UniProt keywords)
     resetLimiter()
     const results = await analyzeGenesStructured(['TP53'], [])
     result = results[0]
@@ -158,38 +115,51 @@ describe('TP53 full analysis (real APIs)', () => {
     expect(result.geneInfo.hgncId).toBe('HGNC:11998')
   })
 
-  test('PubMed returns massive literature corpus for TP53', () => {
-    const pubmed = result.sources.pubmed
-    if (pubmed.error) return
-    // TP53 is one of the most studied genes
-    expect(pubmed.articleCount).toBeGreaterThan(20000)
+  test('PubMed returns massive literature corpus', () => {
+    expect(result.sources.pubmed.error).toBeUndefined()
+    expect(result.sources.pubmed.articleCount).toBeGreaterThan(20000)
   })
 
-  test('ClinVar returns high pathogenic counts for TP53', () => {
-    const clinvar = result.sources.clinvar
-    if (clinvar.error) return
-    expect(clinvar.totalPathogenic).toBeGreaterThan(500)
+  test('ClinVar returns high pathogenic counts', () => {
+    expect(result.sources.clinvar.error).toBeUndefined()
+    expect(result.sources.clinvar.totalPathogenic).toBeGreaterThan(500)
   })
 
-  test('gnomAD shows TP53 is highly constrained', () => {
+  test('gnomAD returns constraint data', () => {
     const c = result.sources.constraints
-    if (c.error) return
-    // TP53 should have constraint data in at least one genome build
+    expect(c.error).toBeUndefined()
     const hasV2 = c.constraints_v2.pLI !== 'N/A'
     const hasV4 = c.constraints_v4.pLI !== 'N/A'
     expect(hasV2 || hasV4).toBe(true)
-    // pLI varies between genome builds; just verify it's a real number
-    if (hasV4) expect(typeof c.constraints_v4.pLI).toBe('number')
+  })
+
+  test('no source errors', () => {
+    expect(result.sourceErrors).toEqual([])
   })
 })
 
-describe('invalid gene (real APIs)', () => {
-  test('returns valid=false for nonsense gene symbol', async () => {
-    cacheClear()
+describe('validateGene', () => {
+  test('validates known gene', async () => {
+    const result = await validateGene('BRCA1')
+    expect(result.valid).toBe(true)
+    expect(result.hgncId).toBe('HGNC:1100')
+    expect(result.geneValidity).toBe('Definitive')
+  }, 30000)
+
+  test('rejects unknown gene', async () => {
     resetLimiter()
-    const results = await analyzeGenesStructured(['XYZNOTAREALGENE999'], [])
-    expect(results).toHaveLength(1)
-    expect(results[0].valid).toBe(false)
-    expect(results[0].error).toContain('not found')
+    const result = await validateGene('XYZNOTAREALGENE999')
+    expect(result.valid).toBe(false)
+    expect(result.message).toContain('not found')
+  }, 30000)
+})
+
+describe('searchLiterature', () => {
+  test('returns articles for known gene', async () => {
+    const result = await searchLiterature('TP53', ['cancer'])
+    expect(result.error).toBeUndefined()
+    expect(result.articleCount).toBeGreaterThan(0)
+    expect(result.articles.length).toBeGreaterThan(0)
+    expect(result.articles[0].pmid).toMatch(/^\d+$/)
   }, 30000)
 })

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1,0 +1,195 @@
+/**
+ * Integration tests — hit real APIs with well-known genes.
+ *
+ * These are slow (30-120s per test) and depend on external services.
+ * Run separately: npm run test:integration
+ *
+ * They verify that the full pipeline produces correct, non-trivial results
+ * for BRCA1 and TP53 — two of the most studied genes in genomics.
+ */
+
+const { analyzeGenesStructured } = require('../services/dataservice')
+const { cacheClear } = require('../utils/cache')
+const { resetLimiter } = require('../utils/rateLimiter')
+
+beforeAll(() => {
+  cacheClear()
+  resetLimiter()
+})
+
+describe('BRCA1 full analysis (real APIs)', () => {
+  let result
+
+  beforeAll(async () => {
+    cacheClear()
+    resetLimiter()
+    const results = await analyzeGenesStructured(['BRCA1'], ['breast cancer'])
+    result = results[0]
+  }, 180000)
+
+  test('gene is validated and identified correctly', () => {
+    expect(result.valid).toBe(true)
+    expect(result.gene).toBe('BRCA1')
+    expect(result.geneInfo.name).toMatch(/BRCA/i)
+    expect(result.geneInfo.hgncId).toBe('HGNC:1100')
+    expect(result.geneInfo.location).toMatch(/17q/)
+    expect(result.geneInfo.ensemblId).toBe('ENSG00000012048')
+    expect(result.geneInfo.omimId).toBe('113705')
+  })
+
+  test('ClinGen validity is Definitive for BRCA1', () => {
+    expect(result.geneInfo.geneValidity).toBe('Definitive')
+  })
+
+  test('PubMed returns articles with metadata', () => {
+    const pubmed = result.sources.pubmed
+    if (pubmed.error) {
+      console.warn(`PubMed was rate-limited: ${pubmed.error}`)
+      return
+    }
+    expect(pubmed.articleCount).toBeGreaterThan(10000)
+    expect(pubmed.articles.length).toBeGreaterThan(0)
+    expect(pubmed.articles.length).toBeLessThanOrEqual(5)
+
+    const article = pubmed.articles[0]
+    expect(article.pmid).toMatch(/^\d+$/)
+    expect(article.title).toBeTruthy()
+    expect(article.title.length).toBeGreaterThan(5)
+    expect(article.journal).toBeTruthy()
+    expect(article.year).toMatch(/^\d{4}$/)
+    expect(pubmed.pubmedUrl).toContain('pubmed.ncbi.nlm.nih.gov')
+  })
+
+  test('ClinVar returns non-trivial pathogenic variant counts', () => {
+    const clinvar = result.sources.clinvar
+    if (clinvar.error) {
+      console.warn(`ClinVar was rate-limited: ${clinvar.error}`)
+      return
+    }
+    expect(clinvar.totalPathogenic).toBeGreaterThan(100)
+    expect(typeof clinvar.lofVariants).toBe('number')
+    expect(typeof clinvar.missenseVariants).toBe('number')
+    expect(clinvar.clinvarUrl).toContain('BRCA1')
+  })
+
+  test('gnomAD returns constraint scores for both genome builds', () => {
+    const constraints = result.sources.constraints
+    if (constraints.error) {
+      console.warn(`gnomAD was unavailable: ${constraints.error}`)
+      return
+    }
+    // BRCA1 is highly constrained — pLI should be near 0 (tolerant of LoF)
+    // or near 1 depending on the version. Just check it's a real number.
+    expect(typeof constraints.constraints_v4.pLI).toBe('number')
+    expect(typeof constraints.constraints_v2.pLI).toBe('number')
+    expect(typeof constraints.constraints_v4.oe_lof_upper).toBe('number')
+    expect(typeof constraints.constraints_v4.mis_z).toBe('number')
+    expect(constraints.gnomadUrl).toContain('BRCA1')
+  })
+
+  test('UniProt returns protein function', () => {
+    const uniprot = result.sources.uniprot
+    if (uniprot.error) {
+      console.warn(`UniProt was unavailable: ${uniprot.error}`)
+      return
+    }
+    expect(uniprot.geneFunction).toBeTruthy()
+    expect(uniprot.geneFunction.length).toBeGreaterThan(20)
+    // BRCA1 is involved in DNA repair
+    expect(uniprot.geneFunction.toLowerCase()).toMatch(/dna|repair|ubiquitin|tumor/i)
+    expect(uniprot.uniprotUrl).toContain('uniprot.org')
+  })
+
+  test('IMPC returns mouse phenotypes', () => {
+    const mouseKO = result.sources.mouseKO
+    if (mouseKO.error) {
+      console.warn(`IMPC was unavailable: ${mouseKO.error}`)
+      return
+    }
+    // BRCA1 knockout mice have phenotypes
+    if (mouseKO.phenotypeCount > 0) {
+      expect(Object.keys(mouseKO.mousePhenotypes).length).toBeGreaterThan(0)
+      expect(mouseKO.impcUrl).toContain('mousephenotype.org')
+    }
+  })
+
+  test('PanelApp returns panel counts', () => {
+    const panelApps = result.sources.panelApps
+    // At least UK should respond
+    if (panelApps.panelAppEnglandCount !== null) {
+      expect(typeof panelApps.panelAppEnglandCount).toBe('number')
+    }
+  })
+
+  test('OMIM returns disease associations', () => {
+    const omim = result.sources.omim
+    if (omim.error) {
+      console.warn(`OMIM was unavailable: ${omim.error}`)
+      return
+    }
+    // BRCA1 is associated with breast/ovarian cancer in OMIM
+    if (omim.mim.length > 0) {
+      const allDescriptions = omim.mim.join(' ').toLowerCase()
+      expect(allDescriptions).toMatch(/breast|ovarian|cancer|carcinoma/i)
+    }
+  })
+
+  test('sourceErrors is an array (may be empty if all sources responded)', () => {
+    expect(Array.isArray(result.sourceErrors)).toBe(true)
+    if (result.sourceErrors.length > 0) {
+      console.warn('Some sources had errors:', result.sourceErrors.map((e) => `${e.source}: ${e.error}`).join(', '))
+    }
+  })
+})
+
+describe('TP53 full analysis (real APIs)', () => {
+  let result
+
+  beforeAll(async () => {
+    // Use the cache from BRCA1 run for shared resources (ClinGen, UniProt keywords)
+    resetLimiter()
+    const results = await analyzeGenesStructured(['TP53'], [])
+    result = results[0]
+  }, 180000)
+
+  test('gene is validated correctly', () => {
+    expect(result.valid).toBe(true)
+    expect(result.geneInfo.name).toMatch(/tumor protein/i)
+    expect(result.geneInfo.hgncId).toBe('HGNC:11998')
+  })
+
+  test('PubMed returns massive literature corpus for TP53', () => {
+    const pubmed = result.sources.pubmed
+    if (pubmed.error) return
+    // TP53 is one of the most studied genes
+    expect(pubmed.articleCount).toBeGreaterThan(20000)
+  })
+
+  test('ClinVar returns high pathogenic counts for TP53', () => {
+    const clinvar = result.sources.clinvar
+    if (clinvar.error) return
+    expect(clinvar.totalPathogenic).toBeGreaterThan(500)
+  })
+
+  test('gnomAD shows TP53 is highly constrained', () => {
+    const c = result.sources.constraints
+    if (c.error) return
+    // TP53 should have constraint data in at least one genome build
+    const hasV2 = c.constraints_v2.pLI !== 'N/A'
+    const hasV4 = c.constraints_v4.pLI !== 'N/A'
+    expect(hasV2 || hasV4).toBe(true)
+    // pLI varies between genome builds; just verify it's a real number
+    if (hasV4) expect(typeof c.constraints_v4.pLI).toBe('number')
+  })
+})
+
+describe('invalid gene (real APIs)', () => {
+  test('returns valid=false for nonsense gene symbol', async () => {
+    cacheClear()
+    resetLimiter()
+    const results = await analyzeGenesStructured(['XYZNOTAREALGENE999'], [])
+    expect(results).toHaveLength(1)
+    expect(results[0].valid).toBe(false)
+    expect(results[0].error).toContain('not found')
+  }, 30000)
+})

--- a/tests/rateLimiter.test.js
+++ b/tests/rateLimiter.test.js
@@ -1,0 +1,91 @@
+const { NcbiRateLimiter } = require('../utils/rateLimiter')
+
+describe('NcbiRateLimiter', () => {
+  test('serializes concurrent requests with minimum spacing', async () => {
+    const limiter = new NcbiRateLimiter(50) // 50ms for fast tests
+    const timestamps = []
+    const mockAxios = {
+      get: jest.fn(async () => {
+        timestamps.push(Date.now())
+        return { data: 'ok' }
+      }),
+    }
+
+    // Fire 3 requests concurrently
+    await Promise.all([
+      limiter.get(mockAxios, 'http://a'),
+      limiter.get(mockAxios, 'http://b'),
+      limiter.get(mockAxios, 'http://c'),
+    ])
+
+    expect(timestamps).toHaveLength(3)
+    // Each subsequent request should be at least ~50ms after the previous
+    expect(timestamps[1] - timestamps[0]).toBeGreaterThanOrEqual(40)
+    expect(timestamps[2] - timestamps[1]).toBeGreaterThanOrEqual(40)
+  })
+
+  test('retries on 429 with backoff', async () => {
+    const limiter = new NcbiRateLimiter(10)
+    const mockAxios = {
+      get: jest
+        .fn()
+        .mockRejectedValueOnce({ response: { status: 429 }, message: '429' })
+        .mockResolvedValueOnce({ data: 'success' }),
+    }
+
+    const result = await limiter.get(mockAxios, 'http://test')
+    expect(result.data).toBe('success')
+    expect(mockAxios.get).toHaveBeenCalledTimes(2)
+  })
+
+  test('retries on 500 server error', async () => {
+    const limiter = new NcbiRateLimiter(10)
+    const mockAxios = {
+      get: jest
+        .fn()
+        .mockRejectedValueOnce({ response: { status: 500 }, message: '500' })
+        .mockResolvedValueOnce({ data: 'recovered' }),
+    }
+
+    const result = await limiter.get(mockAxios, 'http://test')
+    expect(result.data).toBe('recovered')
+  })
+
+  test('retries on network error (no response)', async () => {
+    const limiter = new NcbiRateLimiter(10)
+    const mockAxios = {
+      get: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('ECONNRESET'))
+        .mockResolvedValueOnce({ data: 'ok' }),
+    }
+
+    const result = await limiter.get(mockAxios, 'http://test')
+    expect(result.data).toBe('ok')
+  })
+
+  test('gives up after max retries', async () => {
+    const limiter = new NcbiRateLimiter(10)
+    const mockAxios = {
+      get: jest.fn().mockRejectedValue({ response: { status: 429 }, message: '429' }),
+    }
+
+    await expect(limiter.get(mockAxios, 'http://test')).rejects.toMatchObject({
+      message: '429',
+    })
+    // Initial + 2 retries = 3 total
+    expect(mockAxios.get).toHaveBeenCalledTimes(3)
+  }, 15000)
+
+  test('does not retry on 4xx client errors (except 429)', async () => {
+    const limiter = new NcbiRateLimiter(10)
+    const mockAxios = {
+      get: jest.fn().mockRejectedValue({ response: { status: 400 }, message: 'Bad Request' }),
+    }
+
+    await expect(limiter.get(mockAxios, 'http://test')).rejects.toMatchObject({
+      message: 'Bad Request',
+    })
+    expect(mockAxios.get).toHaveBeenCalledTimes(1) // No retry
+  })
+})

--- a/tests/validateGene-searchLiterature.test.js
+++ b/tests/validateGene-searchLiterature.test.js
@@ -1,0 +1,86 @@
+const axios = require('axios')
+const { validateGene, searchLiterature } = require('../services/dataservice')
+const { cacheClear } = require('../utils/cache')
+const { resetLimiter } = require('../utils/rateLimiter')
+
+jest.mock('axios')
+jest.mock('../utils/rateLimiter', () => ({
+  rateLimitedGet: jest.fn(),
+  resetLimiter: jest.fn(),
+}))
+
+const { rateLimitedGet } = require('../utils/rateLimiter')
+
+const HGNC_XML = `<?xml version="1.0"?>
+<response>
+  <result name="response" numFound="1">
+    <doc>
+      <str name="name">BRCA DNA repair associated</str>
+      <str name="location">17q21.31</str>
+      <str name="hgnc_id">HGNC:1100</str>
+      <str name="ensembl_gene_id">ENSG00000012048</str>
+      <arr name="alias_name"><str>BRCC1</str></arr>
+      <arr name="mane_select"><str>NM_007294.4</str></arr>
+      <arr name="mgd_id"><str>MGI:104537</str></arr>
+      <arr name="uniprot_ids"><str>P38398</str></arr>
+      <arr name="omim_id"><str>113705</str></arr>
+    </doc>
+  </result>
+</response>`
+
+const CLINGEN_CSV = `"GENE SYMBOL","GENE ID (HGNC)","DISEASE","CLASSIFICATION"
+"BRCA1","HGNC:1100","Breast cancer","Definitive"`
+
+describe('validateGene', () => {
+  beforeEach(() => {
+    cacheClear()
+    jest.clearAllMocks()
+  })
+
+  test('returns valid gene data', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: CLINGEN_CSV })
+      if (url.includes('rest.genenames.org')) return Promise.resolve({ status: 200, data: HGNC_XML })
+      return Promise.resolve({ data: {} })
+    })
+
+    const result = await validateGene('BRCA1')
+    expect(result.valid).toBe(true)
+    expect(result.hgncId).toBe('HGNC:1100')
+    expect(result.name).toContain('BRCA')
+    expect(result.geneValidity).toBe('Definitive')
+    expect(result.geneLink).toContain('HGNC:1100')
+    expect(result.ensemblId).toBe('ENSG00000012048')
+    expect(result.maneSelect).toContain('NM_007294.4')
+  })
+
+  test('returns invalid for unknown gene', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('clinicalgenome.org')) return Promise.resolve({ data: CLINGEN_CSV })
+      if (url.includes('rest.genenames.org')) return Promise.resolve({ status: 200, data: '<response><result name="response" numFound="0"></result></response>' })
+      return Promise.resolve({ data: {} })
+    })
+
+    const result = await validateGene('XYZFAKE')
+    expect(result.valid).toBe(false)
+    expect(result.message).toContain('not found')
+  })
+})
+
+describe('searchLiterature', () => {
+  beforeEach(() => {
+    cacheClear()
+    jest.clearAllMocks()
+  })
+
+  test('returns PubMed results', async () => {
+    rateLimitedGet
+      .mockResolvedValueOnce({ data: { esearchresult: { count: '100', idlist: ['12345'] } } })
+      .mockResolvedValueOnce({ data: '<PubmedArticleSet><PubmedArticle><MedlineCitation><PMID>12345</PMID><Article><ArticleTitle>Test article</ArticleTitle><Journal><Title>J</Title><JournalIssue><PubDate><Year>2024</Year></PubDate></JournalIssue></Journal></Article></MedlineCitation><PubmedData><ArticleIdList><ArticleId IdType="pubmed">12345</ArticleId></ArticleIdList></PubmedData></PubmedArticle></PubmedArticleSet>' })
+
+    const result = await searchLiterature('BRCA1', ['cancer'])
+    expect(result.articleCount).toBe(100)
+    expect(result.articles.length).toBe(1)
+    expect(result.articles[0].title).toBe('Test article')
+  })
+})

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -1,0 +1,23 @@
+const DEFAULT_TTL_MS = 60 * 60 * 1000 // 1 hour
+
+const store = new Map()
+
+function cacheGet(key) {
+  const entry = store.get(key)
+  if (!entry) return undefined
+  if (Date.now() > entry.expiresAt) {
+    store.delete(key)
+    return undefined
+  }
+  return entry.data
+}
+
+function cacheSet(key, data, ttlMs = DEFAULT_TTL_MS) {
+  store.set(key, { data, expiresAt: Date.now() + ttlMs })
+}
+
+function cacheClear() {
+  store.clear()
+}
+
+module.exports = { cacheGet, cacheSet, cacheClear }

--- a/utils/fetchGeneCard.js
+++ b/utils/fetchGeneCard.js
@@ -1,57 +1,107 @@
-// utils/fetchGeneCARD.js
 const axios = require('axios')
 const xml2js = require('xml2js')
-const Gene = require('../models/gene.js') // Import the Gene model dzad
-const fs = require('fs')
-const path = require('path')
-const csvParser = require('csv-parser')
+const Gene = require('../models/gene.js')
+const { cacheGet, cacheSet } = require('./cache')
 
-// ranking
-const classificationRanking = ['Definitive', 'Strong', 'Moderate', 'Supportive', 'Limited', 'Disputed Evidence', 'Refuted', 'Animal', 'No Known', 'No Known Disease Relationship'] // Ordered by importance
+const CLINGEN_DOWNLOAD_URL = 'https://search.clinicalgenome.org/kb/gene-validity/download'
+const CLASSIFICATION_RANKING = [
+  'Definitive', 'Strong', 'Moderate', 'Supportive', 'Limited',
+  'Disputed Evidence', 'Refuted', 'Animal', 'No Known', 'No Known Disease Relationship',
+]
 
-const validityMap = new Map()
+let validityMap = null
+let validityLoadPromise = null
 
-function loadCSV() {
-  const csvFilePath = path.join(__dirname, '../BDD/gene_validity.csv')
+/**
+ * Downloads and parses the ClinGen gene validity data from the official endpoint.
+ * Replaces the previous local CSV approach (BDD/gene_validity.csv).
+ * Data is downloaded once at first use and cached in memory.
+ */
+async function loadGeneValidity() {
+  if (validityMap) return validityMap
+  if (validityLoadPromise) return validityLoadPromise
 
-  return new Promise((resolve, reject) => {
-    fs.createReadStream(csvFilePath)
-      .pipe(csvParser())
-      .on('data', (row) => {
-        const hgncId = row['gene_curie']?.trim()
-        const classification = row['classification_title']?.trim()
+  validityLoadPromise = (async () => {
+    try {
+      console.log('[PubMatcher] Downloading ClinGen gene validity data...')
+      const response = await axios.get(CLINGEN_DOWNLOAD_URL, { timeout: 30000 })
+      const lines = response.data.split('\n')
+      const map = new Map()
+
+      // Find header line
+      let headerIndex = -1
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].includes('GENE SYMBOL') && lines[i].includes('CLASSIFICATION')) {
+          headerIndex = i
+          break
+        }
+      }
+      if (headerIndex === -1) {
+        console.warn('[PubMatcher] Warning: Could not parse ClinGen CSV header')
+        validityMap = map
+        return map
+      }
+
+      const header = lines[headerIndex].split('","').map((h) => h.replace(/"/g, '').trim())
+      const geneIdIdx = header.indexOf('GENE ID (HGNC)')
+      const classIdx = header.indexOf('CLASSIFICATION')
+
+      for (let i = headerIndex + 1; i < lines.length; i++) {
+        const line = lines[i].trim()
+        if (!line || line.startsWith('"+++')) continue
+        const fields = line.split('","').map((f) => f.replace(/"/g, '').trim())
+        if (fields.length <= Math.max(geneIdIdx, classIdx)) continue
+        const hgncId = fields[geneIdIdx] || ''
+        const classification = fields[classIdx] || ''
 
         if (hgncId && classification) {
-          if (validityMap.has(hgncId)) {
-            const existingClassification = validityMap.get(hgncId)
-            // Compare, if more important replace
-            if (classificationRanking.indexOf(classification) < classificationRanking.indexOf(existingClassification)) {
-              validityMap.set(hgncId, classification)
+          if (map.has(hgncId)) {
+            const existing = map.get(hgncId)
+            if (CLASSIFICATION_RANKING.indexOf(classification) < CLASSIFICATION_RANKING.indexOf(existing)) {
+              map.set(hgncId, classification)
             }
           } else {
-            // Add
-            validityMap.set(hgncId, classification)
+            map.set(hgncId, classification)
           }
         }
-      })
-      .on('end', () => {
-        resolve(validityMap) // Resolve with the map for further use
-      })
-      .on('error', (error) => {
-        reject(error)
-      })
+      }
+
+      console.log(`[PubMatcher] Loaded ${map.size} gene validity entries from ClinGen`)
+      validityMap = map
+      return map
+    } catch (error) {
+      console.warn(`[PubMatcher] Warning: Failed to load gene validity: ${error.message}`)
+      validityMap = new Map()
+      return validityMap
+    } finally {
+      validityLoadPromise = null
+    }
+  })()
+
+  return validityLoadPromise
+}
+
+function parseXML(xml) {
+  return new Promise((resolve, reject) => {
+    xml2js.parseString(xml, (err, result) => {
+      if (err) reject(err)
+      else resolve(result)
+    })
   })
 }
 
 /**
- * Récupère et valide les informations d'un gène depuis l'API GeneCARD
- * @param {String} gene - Symbole du gène à rechercher
- * @returns {Object|Boolean|null} - Objet contenant les informations validées du gène, false si non trouvé, null en cas d'erreur
+ * Validates a gene symbol against HGNC and enriches with ClinGen validity data.
+ * Now downloads ClinGen data live instead of reading from a local CSV.
  */
 async function fetchGeneCARD(gene) {
+  const cached = cacheGet(`gene:${gene}`)
+  if (cached !== undefined) return cached
+
   try {
     const response = await axios.get(`https://rest.genenames.org/fetch/symbol/${gene}`, {
-      headers: { Accept: 'application/xml' }
+      headers: { Accept: 'application/xml' },
+      timeout: 10000,
     })
     let xmlData = response.data.replace(/^\uFEFF/, '')
 
@@ -61,23 +111,34 @@ async function fetchGeneCARD(gene) {
 
       if (numFound > 0) {
         const doc = parsedData.response.result[0].doc[0]
-        const geneName = doc.str?.find((item) => item.$.name === 'name')?._ || 'No match'
-        const location = doc.str?.find((item) => item.$.name === 'location')?._ || 'No match'
-        const aliasName = doc.arr?.find((item) => item.$.name === 'alias_name')?.str?.[0] || 'No match'
-        const maneSelect = doc.arr?.find((item) => item.$.name === 'mane_select')?.str || 'No match'
-        const mgdId = doc.arr?.find((item) => item.$.name === 'mgd_id')?.str?.[0] || 'No match'
-        const enzymeId = doc.arr?.find((item) => item.$.name === 'enzyme_id')?.str?.[0] || 'No match'
-        const uniprotIds = doc.arr?.find((item) => item.$.name === 'uniprot_ids')?.str?.map((item) => item)[0] || 'No match'
-        const hgncId = doc.str?.find((item) => item.$.name === 'hgnc_id')?._ || 'No match'
-        const rgdId = doc.arr?.find((item) => item.$.name === 'rgd_id')?.str?.[0] || 'No match'
-        const ensemblGeneId = doc.str?.find((item) => item.$.name === 'ensembl_gene_id')?._ || 'No match'
-        const orphanet = doc.int?.find((item) => item.$.name === 'orphanet')?._ || 'No match'
-        const dateModified = doc.date?.find((item) => item.$.name === 'date_modified')?._ || 'No match'
-        const dateApprovedReserved = doc.date?.find((item) => item.$.name === 'date_approved_reserved')?._ || 'No match'
-        const validityMarker = validityMap.get(hgncId) || 'No Known'
-        const omimId = doc.arr?.find((item) => item.$.name === 'omim_id')?.str?.[0] || 'No match'
-        const validatedGene = new Gene(geneName, aliasName, location, maneSelect, mgdId, enzymeId, uniprotIds, hgncId, rgdId, ensemblGeneId, orphanet, dateModified, dateApprovedReserved, validityMarker, omimId)
-        // * RETURN THE RESULT
+        const getStr = (name) => doc.str?.find((item) => item.$.name === name)?._ || null
+        const getArr = (name) => doc.arr?.find((item) => item.$.name === name)?.str || null
+        const getInt = (name) => doc.int?.find((item) => item.$.name === name)?._ || null
+        const getDate = (name) => doc.date?.find((item) => item.$.name === name)?._ || null
+
+        const hgncId = getStr('hgnc_id')
+        const vMap = await loadGeneValidity()
+        const validityMarker = vMap.get(hgncId) || 'No Known'
+
+        const validatedGene = new Gene(
+          getStr('name'),
+          getArr('alias_name')?.[0] || null,
+          getStr('location'),
+          getArr('mane_select') || null,
+          getArr('mgd_id')?.[0] || null,
+          getArr('enzyme_id')?.[0] || null,
+          getArr('uniprot_ids')?.[0] || null,
+          hgncId,
+          getArr('rgd_id')?.[0] || null,
+          getStr('ensembl_gene_id'),
+          getInt('orphanet'),
+          getDate('date_modified'),
+          getDate('date_approved_reserved'),
+          validityMarker,
+          getArr('omim_id')?.[0] || null,
+        )
+
+        cacheSet(`gene:${gene}`, validatedGene)
         return validatedGene
       } else {
         return false
@@ -86,27 +147,9 @@ async function fetchGeneCARD(gene) {
       return null
     }
   } catch (error) {
+    console.error(`HGNC lookup failed for ${gene}: ${error.message}`)
     return null
   }
 }
-
-function parseXML(xml) {
-  return new Promise((resolve, reject) => {
-    xml2js.parseString(xml, (err, result) => {
-      if (err) {
-        reject(err)
-      } else {
-        resolve(result)
-      }
-    })
-  })
-}
-
-;(async () => {
-  //IIAFE
-  try {
-    await loadCSV()
-  } catch (error) {}
-})()
 
 module.exports = fetchGeneCARD

--- a/utils/fetchOMIM.js
+++ b/utils/fetchOMIM.js
@@ -1,32 +1,44 @@
 const axios = require('axios')
+const { cacheGet, cacheSet } = require('./cache')
 
-const fetchMimMorbidData = async (ensemblId) => {
-  const url = `https://rest.ensembl.org/phenotype/gene/homo_sapiens/${ensemblId}?content-type=application/json`
+/**
+ * Fetches OMIM disease associations via the Ensembl phenotype API.
+ * Now includes caching, timeouts, and proper error handling.
+ */
+async function fetchOmimData(ensemblId) {
+  if (!ensemblId) {
+    return { mim: [] }
+  }
+
+  const cacheKey = `omim:${ensemblId}`
+  const cached = cacheGet(cacheKey)
+  if (cached !== undefined) return cached
 
   try {
-    const response = await axios.get(url)
+    const url = `https://rest.ensembl.org/phenotype/gene/homo_sapiens/${ensemblId}?content-type=application/json`
+    const response = await axios.get(url, { timeout: 10000 })
     const phenotypeData = response.data
 
-    const mimMorbidDescriptions = []
+    const mimDescriptions = []
     const seen = new Set()
 
-    phenotypeData.forEach((entry, index) => {
-      // Check if "MIM morbid" exists in the source field
+    for (const entry of phenotypeData) {
       if (entry.source && entry.source.toLowerCase() === 'mim morbid') {
         const description = entry.description || 'No description'
-
-        // Avoid duplicates based on the description
         if (!seen.has(description)) {
-          mimMorbidDescriptions.push(description)
+          mimDescriptions.push(description)
           seen.add(description)
         }
       }
-    })
+    }
 
-    return { mim: mimMorbidDescriptions }
+    const result = { mim: mimDescriptions }
+    cacheSet(cacheKey, result)
+    return result
   } catch (error) {
-    return []
+    console.error(`OMIM/Ensembl fetch failed for ${ensemblId}: ${error.message}`)
+    return { mim: [], error: error.message }
   }
 }
 
-module.exports = fetchMimMorbidData
+module.exports = fetchOmimData

--- a/utils/fetchOMIM.js
+++ b/utils/fetchOMIM.js
@@ -16,7 +16,7 @@ async function fetchOmimData(ensemblId) {
 
   try {
     const url = `https://rest.ensembl.org/phenotype/gene/homo_sapiens/${ensemblId}?content-type=application/json`
-    const response = await axios.get(url, { timeout: 10000 })
+    const response = await axios.get(url, { timeout: 30000 })
     const phenotypeData = response.data
 
     const mimDescriptions = []

--- a/utils/formatters.js
+++ b/utils/formatters.js
@@ -1,0 +1,171 @@
+/**
+ * MCP output formatters — convert structured analysis results into
+ * markdown text for LLM consumption. Extracted from mcp/server.js
+ * so they can be unit-tested without the MCP SDK.
+ */
+
+function formatSourceErrors(sourceErrors) {
+  if (!sourceErrors || sourceErrors.length === 0) return ''
+  const lines = ['\n### Data Source Warnings']
+  for (const { source, error } of sourceErrors) {
+    lines.push(`- **${source}**: unavailable (${error})`)
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+function formatGeneAnalysis(results) {
+  if (!results || results.length === 0) return 'No results returned.'
+
+  const sections = results.map((r) => {
+    if (!r.valid) {
+      return `## ${r.gene}\n**Error**: ${r.error}`
+    }
+
+    const { geneInfo, sources, sourceErrors } = r
+    const lines = [`## ${r.gene} — ${geneInfo.name || 'Unknown'}`]
+
+    if (sourceErrors.length > 0) {
+      lines.push(formatSourceErrors(sourceErrors))
+    }
+
+    lines.push('### Gene Information')
+    lines.push(`- **HGNC ID**: ${geneInfo.hgncId || 'N/A'}`)
+    lines.push(`- **Location**: ${geneInfo.location || 'N/A'}`)
+    lines.push(`- **Alias**: ${geneInfo.alias || 'N/A'}`)
+    lines.push(`- **OMIM ID**: ${geneInfo.omimId || 'N/A'}`)
+    lines.push(`- **Ensembl**: ${geneInfo.ensemblId || 'N/A'}`)
+    lines.push(`- **Gene Validity (ClinGen)**: ${geneInfo.geneValidity}`)
+    if (geneInfo.geneLink) lines.push(`- **GenCC**: ${geneInfo.geneLink}`)
+
+    const uniprot = sources.uniprot
+    if (uniprot && !uniprot.error) {
+      lines.push('### UniProt Function')
+      lines.push(uniprot.geneFunction || 'No function data available.')
+      if (uniprot.bioProcessKeywords?.length > 0) {
+        lines.push(`**Biological processes**: ${uniprot.bioProcessKeywords.join(', ')}`)
+      }
+      if (uniprot.uniprotUrl) lines.push(`**UniProt entry**: ${uniprot.uniprotUrl}`)
+    }
+
+    const constraints = sources.constraints
+    if (constraints && !constraints.error) {
+      lines.push('### gnomAD Constraint Scores')
+      const fmtC = (label, c) => {
+        if (!c || c.pLI === 'N/A') return `**${label}**: No data available`
+        return `**${label}**: pLI=${c.pLI}, o/e LoF upper=${c.oe_lof_upper}, o/e mis upper=${c.oe_mis_upper}, mis_z=${c.mis_z}`
+      }
+      lines.push(fmtC('gnomAD v4 (GRCh38)', constraints.constraints_v4))
+      lines.push(fmtC('gnomAD v2 (GRCh37)', constraints.constraints_v2))
+      if (constraints.constraintsDelta) {
+        lines.push('**Note**: Significant difference between v2 and v4 constraint scores.')
+      }
+      if (constraints.gnomadUrl) lines.push(`**gnomAD page**: ${constraints.gnomadUrl}`)
+    }
+
+    const clinvar = sources.clinvar
+    if (clinvar && !clinvar.error) {
+      lines.push('### ClinVar Variants')
+      lines.push(`- **Pathogenic LoF variants**: ${clinvar.lofVariants}`)
+      lines.push(`- **Pathogenic missense variants**: ${clinvar.missenseVariants}`)
+      lines.push(`- **VUS LoF**: ${clinvar.lofUnknown}`)
+      lines.push(`- **VUS missense**: ${clinvar.missenseUnknown}`)
+      lines.push(`- **Total pathogenic**: ${clinvar.totalPathogenic}`)
+      lines.push(`- **Total likely pathogenic**: ${clinvar.totalLikelyPathogenic}`)
+      if (clinvar.clinvarUrl) lines.push(`**ClinVar page**: ${clinvar.clinvarUrl}`)
+    }
+
+    const pubmed = sources.pubmed
+    if (pubmed && !pubmed.error) {
+      lines.push('### PubMed Literature')
+      lines.push(`**Total articles**: ${pubmed.articleCount}`)
+      if (pubmed.articles?.length > 0) {
+        lines.push('**Top articles**:')
+        for (const a of pubmed.articles) {
+          const authors = a.authors?.join(', ') || ''
+          const citation = [a.journal, a.year].filter(Boolean).join(', ')
+          lines.push(`- ${a.title}${authors ? ` — ${authors}` : ''}${citation ? ` (${citation})` : ''} [PMID: ${a.pmid}]`)
+        }
+      }
+      if (pubmed.pubmedUrl) lines.push(`**PubMed search**: ${pubmed.pubmedUrl}`)
+    }
+
+    const panelApps = sources.panelApps
+    if (panelApps && !panelApps.error) {
+      lines.push('### PanelApp Gene Panels')
+      lines.push(`- **Genomics England (UK)**: ${panelApps.panelAppEnglandCount ?? panelApps.panelAppEnglandError ?? 'N/A'} panels`)
+      lines.push(`- **PanelApp Australia**: ${panelApps.panelAppAustraliaCount ?? panelApps.panelAppAustraliaError ?? 'N/A'} panels`)
+    }
+
+    const mouseKO = sources.mouseKO
+    if (mouseKO && !mouseKO.error && mouseKO.phenotypeCount > 0) {
+      lines.push('### IMPC Mouse Phenotypes')
+      lines.push(`**${mouseKO.phenotypeCount} phenotypes** across ${mouseKO.categoryCount} categories:`)
+      for (const [category, data] of Object.entries(mouseKO.mousePhenotypes)) {
+        const label = category.replace(/_/g, ' ')
+        const names = Array.isArray(data) ? data : data.names || []
+        lines.push(`- **${label}**: ${names.join(', ')}`)
+      }
+      if (mouseKO.impcUrl) lines.push(`**IMPC page**: ${mouseKO.impcUrl}`)
+    }
+
+    const omim = sources.omim
+    if (omim && !omim.error && omim.mim?.length > 0) {
+      lines.push('### OMIM Diseases')
+      for (const desc of omim.mim) {
+        lines.push(`- ${desc}`)
+      }
+    }
+
+    return lines.join('\n')
+  })
+
+  return sections.join('\n\n---\n\n')
+}
+
+function formatValidation(result) {
+  if (!result.valid) {
+    return `**${result.gene}**: Not found in HGNC. ${result.message}`
+  }
+  const lines = [
+    `## ${result.gene} — Validated`,
+    `- **Full name**: ${result.name || 'N/A'}`,
+    `- **Alias**: ${result.alias || 'N/A'}`,
+    `- **Location**: ${result.location || 'N/A'}`,
+    `- **HGNC ID**: ${result.hgncId || 'N/A'}`,
+    `- **OMIM ID**: ${result.omimId || 'N/A'}`,
+    `- **Ensembl ID**: ${result.ensemblId || 'N/A'}`,
+    `- **Gene Validity (ClinGen)**: ${result.geneValidity || 'No Known'}`,
+  ]
+  if (result.maneSelect?.length > 0) {
+    lines.push(`- **MANE Select**: ${result.maneSelect.join(', ')}`)
+  }
+  if (result.geneLink) lines.push(`- **GenCC**: ${result.geneLink}`)
+  return lines.join('\n')
+}
+
+function formatLiterature(result) {
+  const lines = [`## PubMed results for ${result.gene}`]
+  lines.push(`**Total articles found**: ${result.articleCount}`)
+  if (result.error) {
+    lines.push(`\n**Warning**: PubMed query failed (${result.error}). Results may be incomplete.`)
+  }
+  if (result.articles?.length > 0) {
+    lines.push('')
+    for (const a of result.articles) {
+      const authors = a.authors?.join(', ') || ''
+      const citation = [a.journal, a.year].filter(Boolean).join(', ')
+      lines.push(`### ${a.title}`)
+      if (authors) lines.push(`**Authors**: ${authors}`)
+      if (citation) lines.push(`**Published in**: ${citation}`)
+      if (a.doi) lines.push(`**DOI**: ${a.doi}`)
+      lines.push(`**PMID**: ${a.pmid}`)
+      if (a.abstract) lines.push(`\n> ${a.abstract}`)
+      lines.push('')
+    }
+  }
+  if (result.pubmedUrl) lines.push(`**Full PubMed search**: ${result.pubmedUrl}`)
+  return lines.join('\n')
+}
+
+module.exports = { formatGeneAnalysis, formatValidation, formatLiterature, formatSourceErrors }

--- a/utils/getClinVarData.js
+++ b/utils/getClinVarData.js
@@ -28,13 +28,17 @@ async function getClinVarData(gene) {
   if (cached !== undefined) return cached
 
   try {
-    // Serialize queries to respect NCBI rate limits (3 req/s without API key)
-    const lofVariants = await queryCount(gene, 'pathogenic', 'loss of function')
-    const missenseVariants = await queryCount(gene, 'pathogenic', 'missense')
-    const lofUnknown = await queryCount(gene, 'uncertain significance', 'loss of function')
-    const missenseUnknown = await queryCount(gene, 'uncertain significance', 'missense')
-    const totalPathogenic = await queryCount(gene, 'pathogenic', null)
-    const totalLikelyPathogenic = await queryCount(gene, 'likely pathogenic', null)
+    // All 6 queries are independent — fire them all into the rate limiter queue.
+    // The queue serializes them with proper spacing (350ms), but this expresses
+    // the correct intent and benefits from retry logic on each individual query.
+    const [lofVariants, missenseVariants, lofUnknown, missenseUnknown, totalPathogenic, totalLikelyPathogenic] = await Promise.all([
+      queryCount(gene, 'pathogenic', 'loss of function'),
+      queryCount(gene, 'pathogenic', 'missense'),
+      queryCount(gene, 'uncertain significance', 'loss of function'),
+      queryCount(gene, 'uncertain significance', 'missense'),
+      queryCount(gene, 'pathogenic', null),
+      queryCount(gene, 'likely pathogenic', null),
+    ])
 
     const result = {
       lofVariants,

--- a/utils/getClinVarData.js
+++ b/utils/getClinVarData.js
@@ -1,31 +1,64 @@
-const fs = require('fs')
+const axios = require('axios')
+const { cacheGet, cacheSet } = require('./cache')
+const { rateLimitedGet } = require('./rateLimiter')
+
+const EUTILS_BASE = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils'
+
 /**
- * Récupère les données ClinVar pour un gène donné à partir de la base de données JSON locale
- * @param {string} gene - Nom du gène
- * @param {string} jsonFilePath - Chemin vers le fichier JSON contenant les données
- * @returns {Promise<{lofVariants: number, missenseVariants: number, lofUnknown: number, missenseUnknown: number}>}
+ * Queries ClinVar E-utilities API for variant counts by gene, significance, and consequence.
+ * Replaces the previous static JSON file approach (BDD/clinvarCountsPerGene.json).
  */
-async function getClinVarData(gene, jsonFilePath = './BDD/clinvarCountsPerGene.json') {
+async function queryCount(gene, significance, consequence) {
+  const terms = [`${gene}[gene]`, `${significance}[clinsig]`]
+  if (consequence) terms.push(`${consequence}[molecular_consequence]`)
+  const term = terms.join('+AND+')
+  const url = `${EUTILS_BASE}/esearch.fcgi?db=clinvar&term=${term}&rettype=count&retmode=json`
+  const res = await rateLimitedGet(axios, url)
+  return parseInt(res.data.esearchresult?.count, 10) || 0
+}
+
+/**
+ * Fetches ClinVar variant counts for a gene using the live NCBI ClinVar API.
+ * Returns the same keys as before (lofVariants, missenseVariants, lofUnknown, missenseUnknown)
+ * plus new keys (totalPathogenic, totalLikelyPathogenic, clinvarUrl).
+ */
+async function getClinVarData(gene) {
+  const cacheKey = `clinvar:${gene}`
+  const cached = cacheGet(cacheKey)
+  if (cached !== undefined) return cached
+
   try {
-    // Charger les données JSON
-    const data = JSON.parse(fs.readFileSync(jsonFilePath, 'utf8'))
+    // Serialize queries to respect NCBI rate limits (3 req/s without API key)
+    const lofVariants = await queryCount(gene, 'pathogenic', 'loss of function')
+    const missenseVariants = await queryCount(gene, 'pathogenic', 'missense')
+    const lofUnknown = await queryCount(gene, 'uncertain significance', 'loss of function')
+    const missenseUnknown = await queryCount(gene, 'uncertain significance', 'missense')
+    const totalPathogenic = await queryCount(gene, 'pathogenic', null)
+    const totalLikelyPathogenic = await queryCount(gene, 'likely pathogenic', null)
 
-    // Vérifier si le gène existe dans la base
-    if (!data[gene]) {
-      console.warn(`Gène ${gene} introuvable dans la base de données.`)
-      return { lofVariants: 0, missenseVariants: 0, lofUnknown: 0, missenseUnknown: 0 }
+    const result = {
+      lofVariants,
+      missenseVariants,
+      lofUnknown,
+      missenseUnknown,
+      totalPathogenic,
+      totalLikelyPathogenic,
+      clinvarUrl: `https://www.ncbi.nlm.nih.gov/clinvar/?term=${encodeURIComponent(gene)}[gene]`,
     }
-
-    // Retourner les données du gène
-    return {
-      lofVariants: data[gene].lofVariants || 0,
-      missenseVariants: data[gene].missenseVariants || 0,
-      lofUnknown: data[gene].lofUnknown || 0,
-      missenseUnknown: data[gene].missenseUnknown || 0
-    }
+    cacheSet(cacheKey, result)
+    return result
   } catch (error) {
-    console.error(`Erreur lors de la lecture des données ClinVar pour le gène ${gene}:`, error)
-    return { lofVariants: 0, missenseVariants: 0, lofUnknown: 0, missenseUnknown: 0 }
+    console.error(`ClinVar fetch failed for ${gene}: ${error.message}`)
+    return {
+      lofVariants: 0,
+      missenseVariants: 0,
+      lofUnknown: 0,
+      missenseUnknown: 0,
+      totalPathogenic: 0,
+      totalLikelyPathogenic: 0,
+      clinvarUrl: `https://www.ncbi.nlm.nih.gov/clinvar/?term=${encodeURIComponent(gene)}[gene]`,
+      error: error.message,
+    }
   }
 }
 

--- a/utils/getGeneConstraints.js
+++ b/utils/getGeneConstraints.js
@@ -1,102 +1,119 @@
-const path = require('path')
-const fs = require('fs')
-const csv = require('csv-parser')
+const axios = require('axios')
+const { cacheGet, cacheSet } = require('./cache')
 
-let constraints = {}
-loadConstraints('v2', 'constraints_v2.csv')
-loadConstraints('v4', 'constraints_v4.csv')
-const constraints_v2 = constraints.v2 || {}
-const constraints_v4 = constraints.v4 || {}
+const GNOMAD_API = 'https://gnomad.broadinstitute.org/api'
 
-// TODO Refactor needed
-async function getGeneConstraints(gene) {
-  let geneConstraintsV2 = null
-  let geneConstraintsV4 = null
-  let constraintsDelta = false
-
-  emptyConstraints = {
-    pLI: 'N/A',
-    oe_mis_upper: 'N/A',
-    oe_lof_upper: 'N/A',
-    mis_z: 'N/A'
-  }
-
-  if (constraints_v2[gene]) {
-    geneConstraintsV2 = constraints_v2[gene]
-  } else {
-    geneConstraintsV2 = emptyConstraints
-    constraintsDelta = true
-  }
-
-  if (constraints_v4[gene]) {
-    geneConstraintsV4 = constraints_v4[gene]
-  } else {
-    geneConstraintsV4 = emptyConstraints
-    constraintsDelta = true
-  }
-
-  if (JSON.stringify(geneConstraintsV2) === JSON.stringify(geneConstraintsV4)) {
-    constraintsDelta = false //If both na dnt flag
-  }
-
-  if (constraints_v2[gene] && constraints_v4[gene]) {
-    const parseValue = (value) => parseFloat(value.toString().replace(',', '.'))
-
-    const v2 = {
-      oe_mis_upper: parseValue(constraints_v2[gene].oe_mis_upper),
-      oe_lof_upper: parseValue(constraints_v2[gene].oe_lof_upper),
-      pLI: parseValue(constraints_v2[gene].pLI),
-      mis_z: parseValue(constraints_v2[gene].mis_z)
-    }
-
-    const v4 = {
-      oe_mis_upper: parseValue(constraints_v4[gene].oe_mis_upper),
-      oe_lof_upper: parseValue(constraints_v4[gene].oe_lof_upper),
-      pLI: parseValue(constraints_v4[gene].pLI),
-      mis_z: parseValue(constraints_v4[gene].mis_z)
-    }
-
-    const perc = 1.5 // * threshold
-    if (v2.pLI === 0 || v4.pLI === 0) {
-      constraintsDelta = v2.pLI !== v4.pLI
-    } else {
-      const conditionPLi = v4.pLI >= v2.pLI * perc || v4.pLI <= v2.pLI / perc
-      constraintsDelta = conditionPLi
+const CONSTRAINT_QUERY = `
+query GeneConstraint($geneSymbol: String!) {
+  gene(gene_symbol: $geneSymbol, reference_genome: GRCh38) {
+    gene_id
+    symbol
+    gnomad_constraint {
+      pLI
+      oe_mis
+      oe_mis_lower
+      oe_mis_upper
+      oe_lof
+      oe_lof_lower
+      oe_lof_upper
+      mis_z
+      lof_z
     }
   }
+}
+`
 
-  // * RETURN THE RESULT
+const CONSTRAINT_QUERY_V2 = `
+query GeneConstraintV2($geneSymbol: String!) {
+  gene(gene_symbol: $geneSymbol, reference_genome: GRCh37) {
+    gene_id
+    symbol
+    gnomad_constraint {
+      pLI
+      oe_mis
+      oe_mis_lower
+      oe_mis_upper
+      oe_lof
+      oe_lof_lower
+      oe_lof_upper
+      mis_z
+      lof_z
+    }
+  }
+}
+`
+
+function extractConstraints(geneData) {
+  const c = geneData?.gnomad_constraint
+  if (!c) return { pLI: 'N/A', oe_mis_upper: 'N/A', oe_lof_upper: 'N/A', mis_z: 'N/A' }
   return {
-    constraints_v2: geneConstraintsV2,
-    constraints_v4: geneConstraintsV4,
-    constraintsDelta
+    pLI: c.pLI != null ? Number(c.pLI.toFixed(4)) : 'N/A',
+    oe_mis_upper: c.oe_mis_upper != null ? Number(c.oe_mis_upper.toFixed(4)) : 'N/A',
+    oe_lof_upper: c.oe_lof_upper != null ? Number(c.oe_lof_upper.toFixed(4)) : 'N/A',
+    mis_z: c.mis_z != null ? Number(c.mis_z.toFixed(4)) : 'N/A',
+    oe_mis: c.oe_mis != null ? Number(c.oe_mis.toFixed(4)) : 'N/A',
+    oe_lof: c.oe_lof != null ? Number(c.oe_lof.toFixed(4)) : 'N/A',
+    lof_z: c.lof_z != null ? Number(c.lof_z.toFixed(4)) : 'N/A',
   }
 }
 
-function loadConstraints(datasetKey, fileName) {
-  const constraintsPath = path.join(__dirname, '..', 'BDD', fileName)
-
-  // Ensure constraints container for the datasetKey exists
-  if (!constraints[datasetKey]) {
-    constraints[datasetKey] = {}
+function computeDelta(v2, v4) {
+  const emptyConstraints = { pLI: 'N/A', oe_mis_upper: 'N/A', oe_lof_upper: 'N/A', mis_z: 'N/A' }
+  if (
+    JSON.stringify(v2) === JSON.stringify(emptyConstraints) &&
+    JSON.stringify(v4) === JSON.stringify(emptyConstraints)
+  ) {
+    return false
   }
+  if (v2.pLI !== 'N/A' && v4.pLI !== 'N/A') {
+    const threshold = 1.5
+    if (v2.pLI === 0 || v4.pLI === 0) return v2.pLI !== v4.pLI
+    return v4.pLI >= v2.pLI * threshold || v4.pLI <= v2.pLI / threshold
+  }
+  return v2.pLI !== v4.pLI
+}
 
-  fs.createReadStream(constraintsPath)
-    .pipe(csv({ separator: ';' }))
-    .on('data', (row) => {
-      constraints[datasetKey][row.gene] = {
-        pLI: row.pLI,
-        oe_mis_upper: row.oe_mis_upper,
-        oe_lof_upper: row.oe_lof_upper,
-        mis_z: row.mis_z
-      }
-    })
-    .on('end', () => {
-      console.log(`Constraints CSV file (${datasetKey}) successfully processed`)
-    })
-    .on('error', (error) => {
-      console.error(`Error reading constraints CSV (${datasetKey}):`, error)
-    })
+/**
+ * Fetches gene constraint scores from the gnomAD GraphQL API (v2 + v4).
+ * Replaces the previous static CSV file approach (BDD/constraints_v2.csv, constraints_v4.csv).
+ *
+ * Returns the same keys as before (constraints_v2, constraints_v4, constraintsDelta)
+ * plus gnomadUrl and additional constraint fields (oe_mis, oe_lof, lof_z).
+ */
+async function getGeneConstraints(gene) {
+  const cacheKey = `constraints:${gene}`
+  const cached = cacheGet(cacheKey)
+  if (cached !== undefined) return cached
+
+  try {
+    const [v4Res, v2Res] = await Promise.all([
+      axios.post(GNOMAD_API, { query: CONSTRAINT_QUERY, variables: { geneSymbol: gene } }, { timeout: 15000 }),
+      axios.post(GNOMAD_API, { query: CONSTRAINT_QUERY_V2, variables: { geneSymbol: gene } }, { timeout: 15000 }),
+    ])
+
+    const constraintsV4 = extractConstraints(v4Res.data?.data?.gene)
+    const constraintsV2 = extractConstraints(v2Res.data?.data?.gene)
+    const constraintsDelta = computeDelta(constraintsV2, constraintsV4)
+
+    const result = {
+      constraints_v2: constraintsV2,
+      constraints_v4: constraintsV4,
+      constraintsDelta,
+      gnomadUrl: `https://gnomad.broadinstitute.org/gene/${gene}?dataset=gnomad_r4`,
+    }
+    cacheSet(cacheKey, result)
+    return result
+  } catch (error) {
+    console.error(`gnomAD fetch failed for ${gene}: ${error.message}`)
+    const empty = { pLI: 'N/A', oe_mis_upper: 'N/A', oe_lof_upper: 'N/A', mis_z: 'N/A' }
+    return {
+      constraints_v2: empty,
+      constraints_v4: empty,
+      constraintsDelta: false,
+      gnomadUrl: `https://gnomad.broadinstitute.org/gene/${gene}?dataset=gnomad_r4`,
+      error: error.message,
+    }
+  }
 }
 
 module.exports = getGeneConstraints

--- a/utils/getMouseKO.js
+++ b/utils/getMouseKO.js
@@ -1,107 +1,106 @@
 const axios = require('axios')
-const cheerio = require('cheerio')
 const path = require('path')
 const fs = require('fs')
+const { cacheGet, cacheSet } = require('./cache')
 
 let svgIcons = []
 
+/**
+ * Fetches mouse knockout phenotypes from the IMPC SOLR API.
+ * Now includes caching, timeouts, and proper error handling.
+ * SVG icon loading is preserved for web app backward compatibility.
+ */
 async function getMouseKO(mgdId) {
-  const mouseUrl = `https://www.ebi.ac.uk/mi/impc/solr/genotype-phenotype/select?q=marker_accession_id:"${mgdId}"`
-  const matchingPhenotypes = []
-  const groupedPhenotypes = {}
+  if (!mgdId) {
+    return { mousePhenotypes: {}, impcUrl: null }
+  }
+
+  const cacheKey = `impc:${mgdId}`
+  const cached = cacheGet(cacheKey)
+  if (cached !== undefined) return cached
+
+  const impcUrl = `https://www.mousephenotype.org/data/genes/${mgdId}`
 
   try {
-    // * FETCH MOUSE API
-    const mouseResponse = await axios.get(mouseUrl)
-    mouseResponse.data.response.docs.forEach((doc) => {
-      const phenotype = {
-        phenotypeName: doc.mp_term_name, // Set the phenotype name
-        phenotypeCategory: doc.top_level_mp_term_name[0].replace(/[^a-zA-Z0-9]/g, '_').toLowerCase() // Set the phenotype category
-      }
-      matchingPhenotypes.push(phenotype) // Add to the list of matching phenotypes
-    })
+    const url = `https://www.ebi.ac.uk/mi/impc/solr/genotype-phenotype/select?q=marker_accession_id:"${mgdId}"&rows=500&wt=json`
+    const response = await axios.get(url, { timeout: 10000 })
+    const docs = response.data.response?.docs || []
 
-    // * REMOVE DUPLICATES
-    const matchingPhenotypesNoDuplicates = [...new Map(matchingPhenotypes.map((item) => [item.phenotypeName, item])).values()]
+    const groupedPhenotypes = {}
+    const seen = new Set()
 
-    matchingPhenotypesNoDuplicates.forEach((item) => {
-      const { phenotypeCategory, phenotypeName } = item
+    for (const doc of docs) {
+      const name = doc.mp_term_name
+      const category = (doc.top_level_mp_term_name?.[0] || 'other')
+        .replace(/[^a-zA-Z0-9]/g, '_')
+        .toLowerCase()
 
-      if (!groupedPhenotypes[phenotypeCategory]) {
-        groupedPhenotypes[phenotypeCategory] = {
+      if (seen.has(name)) continue
+      seen.add(name)
+
+      if (!groupedPhenotypes[category]) {
+        groupedPhenotypes[category] = {
           names: [],
-          icon: null
+          icon: null,
         }
       }
-      groupedPhenotypes[phenotypeCategory].names.push(phenotypeName)
-      let matchingIcon = 'NoICONFOUND'
 
-      try {
-        for (const key in svgIcons) {
-          if (svgIcons[key].name === phenotypeCategory) {
-            matchingIcon = svgIcons[key]
-            groupedPhenotypes[phenotypeCategory].icon = matchingIcon ? matchingIcon.path.replace(/^"|"$/g, '') : ''
-            break
-          }
-        }
-      } catch (error) {
-        console.error('Error finding SVG icon for category')
+      groupedPhenotypes[category].names.push(name.charAt(0).toUpperCase() + name.slice(1))
+
+      // Match SVG icon for web app
+      const matchingIcon = svgIcons.find((icon) => icon.name === category)
+      if (matchingIcon) {
+        groupedPhenotypes[category].icon = matchingIcon.path.replace(/^"|"$/g, '')
       }
-    })
+    }
+
+    // Add "noMatch" fallback for web app
+    if (Object.keys(groupedPhenotypes).length === 0) {
+      groupedPhenotypes['noMatch'] = {
+        names: ['No Match'],
+        icon: svgIcons.find((icon) => icon.name === 'noMatch')?.path.replace(/^"|"$/g, '') || '',
+      }
+    }
+
+    const result = {
+      mousePhenotypes: groupedPhenotypes,
+      phenotypeCount: seen.size,
+      categoryCount: Object.keys(groupedPhenotypes).length,
+      impcUrl,
+    }
+    cacheSet(cacheKey, result)
+    return result
   } catch (error) {
-    console.error('Error fetching phenotypes from IMPC')
-  }
-
-  //Add caps to first word of each phenotypes
-  for (const category in groupedPhenotypes) {
-    groupedPhenotypes[category].names = groupedPhenotypes[category].names.map((name) => {
-      return name.charAt(0).toUpperCase() + name.slice(1)
-    })
-  }
-
-  //GOOFY ASS
-  if (Object.keys(groupedPhenotypes).length === 0) {
-    groupedPhenotypes['noMatch'] = {
-      names: ['No Match'], // Add "No Match" as the name
-      icon: svgIcons.find((icon) => icon.name === 'noMatch')?.path.replace(/^"|"$/g, '') || '' // Add the SVG icon
+    console.error(`IMPC fetch failed for ${mgdId}: ${error.message}`)
+    return {
+      mousePhenotypes: {},
+      phenotypeCount: 0,
+      categoryCount: 0,
+      impcUrl,
+      error: error.message,
     }
   }
-  //NoMatch icon
-  if (Object.keys(groupedPhenotypes).length === 0) {
-    result.mousePhenotype = 'No match'
-  }
-  // * RETURN THE RESULT
-  impcUrl = `https://www.mousephenotype.org/data/genes/${mgdId}`
-  return { mousePhenotypes: groupedPhenotypes, impcUrl: impcUrl }
 }
 
 function loadSVGIcons() {
-  const entries = []
-  const folderPath = 'BDD/SVG/'
-
-  // Lire tous les fichiers dans le dossier
-  const files = fs.readdirSync(folderPath)
-
-  files.forEach((file) => {
-    const filePath = path.join(folderPath, file)
-
-    // Vérifier si le fichier est un SVG
-    if (path.extname(file) === '.svg') {
-      // Lire le contenu du fichier SVG
-      let svgContent = fs.readFileSync(filePath, 'utf-8')
-
-      svgContent = svgContent
-        .replace(/width="[^"]*"/, 'width="25px"') // DEGUELASSE A CHANGER ASAP
-        .replace(/height="[^"]*"/, 'height="25px"')
-
-      // Push the modified SVG icon to the array
-      svgIcons.push({
-        name: path.basename(file, '.svg'), // File name without extension
-        path: svgContent // Modified SVG content
-      })
-    }
-  })
-  return svgIcons
+  const folderPath = path.join(__dirname, '..', 'BDD', 'SVG')
+  try {
+    const files = fs.readdirSync(folderPath)
+    files.forEach((file) => {
+      if (path.extname(file) === '.svg') {
+        let svgContent = fs.readFileSync(path.join(folderPath, file), 'utf-8')
+        svgContent = svgContent
+          .replace(/width="[^"]*"/, 'width="25px"')
+          .replace(/height="[^"]*"/, 'height="25px"')
+        svgIcons.push({
+          name: path.basename(file, '.svg'),
+          path: svgContent,
+        })
+      }
+    })
+  } catch {
+    // SVG folder may not exist in MCP-only mode — that's fine
+  }
 }
 
 loadSVGIcons()

--- a/utils/getPanelApps.js
+++ b/utils/getPanelApps.js
@@ -1,43 +1,63 @@
 const axios = require('axios')
+const { cacheGet, cacheSet } = require('./cache')
 
 const HEADERS = {
-  'User-Agent': 'PubMatcher/1.0 (https://github.com/your-org/PubMatcher; genomics-research-tool)'
+  'User-Agent': 'PubMatcher/1.0 (genomics-research-tool)',
 }
 
+/**
+ * Fetches gene panel data from PanelApp UK and Australia.
+ * Now includes caching, timeouts, proper error handling per source,
+ * and a fallback to the PanelApp Australia staging endpoint.
+ */
 async function getPanelApps(gene) {
+  const cacheKey = `panelapp:${gene}`
+  const cached = cacheGet(cacheKey)
+  if (cached !== undefined) return cached
+
   let panelAppEnglandCount = null
   let panelAppAustraliaCount = null
   let panelAppEnglandError = null
   let panelAppAustraliaError = null
 
   try {
-    const res = await axios.get(`https://panelapp.genomicsengland.co.uk/api/v1/genes/?entity_name=${gene}&format=json`, { headers: HEADERS })
+    const res = await axios.get(
+      `https://panelapp.genomicsengland.co.uk/api/v1/genes/?entity_name=${encodeURIComponent(gene)}&format=json`,
+      { headers: HEADERS, timeout: 10000 },
+    )
     panelAppEnglandCount = res.data.count
   } catch (error) {
-    console.error(`Error fetching PanelApp England data for gene ${gene}: `, error.message)
-    panelAppEnglandError = `PanelApp UK is currently unavailable`
+    panelAppEnglandError = 'PanelApp UK is currently unavailable'
+    console.error(`PanelApp UK failed for ${gene}: ${error.message}`)
   }
 
   try {
-    const res = await axios.get(`https://panelapp-aus.org/api/v1/genes/?entity_name=${gene}&format=json`, { headers: HEADERS })
+    const res = await axios.get(
+      `https://panelapp-aus.org/api/v1/genes/?entity_name=${encodeURIComponent(gene)}&format=json`,
+      { headers: HEADERS, timeout: 10000 },
+    )
     panelAppAustraliaCount = res.data.count
-  } catch (error) {
-    console.warn(`PanelApp Australia main instance failed for gene ${gene}, trying fallback...`)
+  } catch {
     try {
-      const res = await axios.get(`https://panelapp-aus-staging.org/api/v1/genes/?entity_name=${gene}&format=json`, { headers: HEADERS })
+      const res = await axios.get(
+        `https://panelapp-aus-staging.org/api/v1/genes/?entity_name=${encodeURIComponent(gene)}&format=json`,
+        { headers: HEADERS, timeout: 10000 },
+      )
       panelAppAustraliaCount = res.data.count
-    } catch (fallbackError) {
-      console.error(`Error fetching PanelApp Australia data for gene ${gene}: `, fallbackError.message)
-      panelAppAustraliaError = `PanelApp Australia is currently unavailable`
+    } catch (error) {
+      panelAppAustraliaError = 'PanelApp Australia is currently unavailable'
+      console.error(`PanelApp Australia failed for ${gene}: ${error.message}`)
     }
   }
 
-  return {
+  const result = {
     panelAppEnglandCount,
     panelAppAustraliaCount,
     panelAppEnglandError,
-    panelAppAustraliaError
+    panelAppAustraliaError,
   }
+  cacheSet(cacheKey, result)
+  return result
 }
 
 module.exports = getPanelApps

--- a/utils/getPubMedData.js
+++ b/utils/getPubMedData.js
@@ -1,100 +1,150 @@
 const axios = require('axios')
-const cheerio = require('cheerio')
+const xml2js = require('xml2js')
+const { cacheGet, cacheSet } = require('./cache')
+const { rateLimitedGet } = require('./rateLimiter')
 
+const EUTILS_BASE = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils'
+
+/**
+ * Fetches PubMed data for a gene using the official NCBI E-utilities API.
+ * Replaces the previous cheerio-based web scraping approach.
+ *
+ * Returns both legacy keys (gene, url, firstArticleTitle, firstArticleUrl, complArticles, count)
+ * for backward compatibility with the web app, and enhanced keys (articles, articleCount, pubmedUrl)
+ * with full article metadata (abstracts, DOIs, authors, journals) for the MCP server.
+ */
 async function getPubMedData(gene, phenotypes) {
-  // * BUILD THE QUERY
-  let combinedQuery = ''
+  let query
   if (phenotypes.length > 0) {
-    const queries = phenotypes.map((phenotype) => `(${gene} AND ${phenotype})`)
-    combinedQuery = queries.join(' OR ')
+    const parts = phenotypes.map((p) => `(${gene} AND ${p})`)
+    query = parts.join(' OR ')
   } else {
-    combinedQuery = `${gene}`
+    query = gene
   }
 
-  // * FETCH DATA
-  const url = `https://pubmed.ncbi.nlm.nih.gov/?term=${encodeURIComponent(combinedQuery)}`
-  const response = await axios.get(url)
-  const $ = cheerio.load(response.data)
+  const cacheKey = `pubmed:${query}`
+  const cached = cacheGet(cacheKey)
+  if (cached !== undefined) return cached
 
-  // * GET ARTICLE COUNT
-  const countSelector = '#search-results > div.top-wrapper > div.results-amount-container > div.results-amount > h3 > span'
-  const countText = $(countSelector).text().trim().replace(',', '')
-  let count = parseInt(countText, 10) || 0
+  const pubmedUrl = `https://pubmed.ncbi.nlm.nih.gov/?term=${encodeURIComponent(query)}`
 
-  // * CHECK IF RESPONSE HAS SPELLCHECK WARNING
-  const spellCheckWarningSelector = '#spell-check-warning'
-  const spellCheckOnly = 'Showing results for'
-  const warningText = $(spellCheckWarningSelector).text().trim()
-  const isAutocorrected = warningText.includes(spellCheckOnly)
+  try {
+    // Step 1: E-search to get PMIDs + count
+    const searchUrl = `${EUTILS_BASE}/esearch.fcgi?db=pubmed&term=${encodeURIComponent(query)}&retmax=5&sort=relevance&retmode=json`
+    const searchRes = await rateLimitedGet(axios, searchUrl)
+    const searchData = searchRes.data.esearchresult
+    const count = parseInt(searchData.count, 10) || 0
+    const pmids = searchData.idlist || []
 
-  // NO RESULT CHECK
-  const zeroResultsBannerSelector = '.solr-message.query-error-message.usa-alert.usa-alert-slim.usa-alert-warning .usa-alert-body .usa-alert-text'
-  const zeroResultsBannerText = $(zeroResultsBannerSelector).text().trim()
-  const hasZeroResultsBanner = zeroResultsBannerText.includes('Your search was processed without automatic term mapping because it retrieved zero results.')
+    if (count === 0 || pmids.length === 0) {
+      const result = {
+        gene,
+        url: pubmedUrl,
+        firstArticleTitle: 'No articles found',
+        firstArticleUrl: null,
+        complArticles: [],
+        count: 0,
+        articles: [],
+        articleCount: 0,
+        pubmedUrl,
+      }
+      cacheSet(cacheKey, result)
+      return result
+    }
 
-  if (hasZeroResultsBanner) {
+    // Step 2: E-fetch to get article details (XML)
+    const fetchUrl = `${EUTILS_BASE}/efetch.fcgi?db=pubmed&id=${pmids.join(',')}&retmode=xml`
+    const fetchRes = await rateLimitedGet(axios, fetchUrl)
+    const parsed = await xml2js.parseStringPromise(fetchRes.data, { explicitArray: false })
+
+    let articleSet = parsed.PubmedArticleSet?.PubmedArticle
+    if (!articleSet) articleSet = []
+    if (!Array.isArray(articleSet)) articleSet = [articleSet]
+
+    const articles = articleSet.slice(0, 5).map((entry) => {
+      const article = entry.MedlineCitation?.Article || {}
+      const pmid = entry.MedlineCitation?.PMID?._ || entry.MedlineCitation?.PMID || ''
+
+      // Title
+      let title = article.ArticleTitle || ''
+      if (typeof title === 'object') title = title._ || JSON.stringify(title)
+
+      // Abstract
+      let abstract = ''
+      const abstractText = article.Abstract?.AbstractText
+      if (typeof abstractText === 'string') {
+        abstract = abstractText
+      } else if (Array.isArray(abstractText)) {
+        abstract = abstractText.map((t) => (typeof t === 'string' ? t : t._ || '')).join(' ')
+      } else if (abstractText && typeof abstractText === 'object') {
+        abstract = abstractText._ || ''
+      }
+
+      // Authors
+      let authors = []
+      const authorList = article.AuthorList?.Author
+      if (Array.isArray(authorList)) {
+        authors = authorList.slice(0, 5).map((a) => {
+          const last = a.LastName || ''
+          const initials = a.Initials || ''
+          return `${last} ${initials}`.trim()
+        })
+        if (authorList.length > 5) authors.push('et al.')
+      }
+
+      // Journal + Year
+      const journal = article.Journal?.Title || ''
+      const year = article.Journal?.JournalIssue?.PubDate?.Year || ''
+
+      // DOI
+      let doi = ''
+      const idList = entry.PubmedData?.ArticleIdList?.ArticleId
+      if (Array.isArray(idList)) {
+        const doiEntry = idList.find((id) => id.$?.IdType === 'doi')
+        doi = doiEntry?._ || doiEntry || ''
+      }
+
+      return { pmid, title, authors, journal, year, doi, abstract: abstract.substring(0, 400) }
+    })
+
+    // Build backward-compatible keys for the web app
+    const firstArticle = articles[0] || null
+    const firstArticleTitle = firstArticle ? firstArticle.title : 'No articles found'
+    const firstArticleUrl = firstArticle ? `https://pubmed.ncbi.nlm.nih.gov/${firstArticle.pmid}/` : null
+    const complArticles = articles.slice(1, 4).map((a) => ({
+      title: a.title,
+      url: `https://pubmed.ncbi.nlm.nih.gov/${a.pmid}/`,
+    }))
+
+    const result = {
+      // Legacy keys (web app backward compat)
+      gene,
+      url: pubmedUrl,
+      firstArticleTitle,
+      firstArticleUrl,
+      complArticles,
+      count,
+      // Enhanced keys (MCP server + future use)
+      articles,
+      articleCount: count,
+      pubmedUrl,
+    }
+    cacheSet(cacheKey, result)
+    return result
+  } catch (error) {
+    console.error(`PubMed fetch failed for ${gene}: ${error.message}`)
     return {
       gene,
-      url,
+      url: pubmedUrl,
       firstArticleTitle: 'No articles found',
       firstArticleUrl: null,
       complArticles: [],
-      count: 0
+      count: 0,
+      articles: [],
+      articleCount: 0,
+      pubmedUrl,
+      error: error.message,
     }
-  }
-
-  // * DEFAULT VALUES
-  let firstArticleTitle = 'No articles found'
-  let firstArticleUrl = null
-  const complArticles = []
-
-  if (!isAutocorrected) {
-    const articles = $('#search-results > section > div.search-results-chunks > div > article')
-
-    // * ITERATE THROUGH ARTICLES
-    articles.each((index, article) => {
-      const titleElement = $(article).find('.docsum-wrap > .docsum-content > a')
-      const title = titleElement.text().trim()
-      const href = titleElement.attr('href')
-
-      if (title && href) {
-        const match = href.match(/\/(\d+)\//)
-        const articleId = match ? match[1] : null
-        const articleUrl = articleId ? `https://pubmed.ncbi.nlm.nih.gov/${articleId}/` : null
-
-        if (index === 0) {
-          // First article
-          firstArticleTitle = title
-          firstArticleUrl = articleUrl
-        } else if (index >= 1 && index <= 3) {
-          // Second, third, and fourth articles
-          complArticles.push({ title, url: articleUrl })
-        }
-
-        if (index >= 3) return false // Stop after the fourth article
-      }
-    })
-  } else {
-    firstArticleUrl = `https://pubmed.ncbi.nlm.nih.gov/${combinedQuery}/`
-  }
-
-  const requestPath = response.request.path
-  if (!requestPath.includes('term')) {
-    firstArticleTitle = $('#full-view-heading > h1.heading-title').text().trim()
-    count = 1
-  } else {
-    firstArticleTitle = firstArticleTitle || 'No PubMed Articles'
-    count = isNaN(count) ? 0 : count
-  }
-
-  // * RETURN THE RESULT
-  return {
-    gene,
-    url,
-    firstArticleTitle,
-    firstArticleUrl,
-    complArticles, // Array of second, third, and fourth articles
-    count
   }
 }
 

--- a/utils/getUniProtFunction.js
+++ b/utils/getUniProtFunction.js
@@ -1,60 +1,112 @@
 const axios = require('axios')
+const { cacheGet, cacheSet } = require('./cache')
 
-async function getUniProtFunction(uniprotId) {
-  try {
-    // * FETCH UNIPROT API
-    const uniProtApiUrl = `https://www.ebi.ac.uk/proteins/api/proteins/${uniprotId}.xml`
-    const urlAccession = `https://www.uniprot.org/uniprotkb/${uniprotId}/entry`
+let keywordsData = null
+let keywordsLoadPromise = null
 
-    const response = await axios.get(uniProtApiUrl, { headers: { Accept: 'application/json' } })
-    // * FETCH KEYWORDS LIST
-    const getKeywordsCSV = await axios.get('https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/docs/keywlist.txt')
-    const keywordsCSV = getKeywordsCSV.data
-    let functionKeywords = []
-    const bioProcessKeywordsOnly = []
+async function loadKeywords() {
+  if (keywordsData) return keywordsData
+  if (keywordsLoadPromise) return keywordsLoadPromise
 
-    if (response.status === 200) {
-      const data = response.data
-      let geneFunction = null
-      if (data.comments && Array.isArray(data.comments)) {
-        data.comments.some((element) => {
-          if (element.type === 'FUNCTION') {
-            // * STORE GENE FUNCTION
-            geneFunction = element.text[0].value
-            // * TRUNCATE IF TEXT IS TOO LONG
-            if (geneFunction && geneFunction.length > 300) {
-              geneFunction = geneFunction.substring(0, 300) + '... '
-            }
-            // * EXTRACT FUNCTION KEYWORDS
-            for (let i = 0; i < Object.keys(data.keywords).length; i++) {
-              functionKeywords.push(data.keywords[i].value)
-            }
-            // * GET ONLY BIOLOGICAL PROCESS KEYWORDS
-            functionKeywords.forEach((keyword) => {
-              const keywordEntry = keywordsCSV.split('//').find((entry) => entry.includes(`ID   ${keyword}`))
-              if (keywordEntry) {
-                const isBiologicalProcess = keywordEntry.split('\n').some((line) => line.startsWith('CA') && line.includes('Biological process'))
-                if (isBiologicalProcess) {
-                  bioProcessKeywordsOnly.push(keyword)
-                }
-              }
-            })
-            return true // ! Exit once keyword has been found
-          }
-        })
-      }
-      // * RETURN THE RESULT
-      return {
-        geneFunction,
-        bioProcessKeywordsOnly,
-        urlAccession
-      }
-    } else {
-      console.error(`UniProt API responded with status: ${response.status}`)
-      return 'No match'
+  keywordsLoadPromise = (async () => {
+    try {
+      console.log('[PubMatcher] Downloading UniProt keywords list...')
+      const res = await axios.get(
+        'https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/docs/keywlist.txt',
+        { timeout: 30000 },
+      )
+      keywordsData = res.data
+      console.log('[PubMatcher] UniProt keywords loaded')
+      return keywordsData
+    } catch (error) {
+      console.warn(`[PubMatcher] Warning: Failed to load UniProt keywords: ${error.message}`)
+      keywordsData = ''
+      return keywordsData
+    } finally {
+      keywordsLoadPromise = null
     }
+  })()
+
+  return keywordsLoadPromise
+}
+
+/**
+ * Fetches protein function and biological process keywords from UniProt.
+ * Now includes caching, parallel fetching of keywords, and proper timeouts.
+ *
+ * Returns both legacy keys (geneFunction, bioProcessKeywordsOnly, urlAccession)
+ * for backward compatibility, and enhanced keys (bioProcessKeywords, uniprotUrl).
+ */
+async function getUniProtFunction(uniprotId) {
+  if (!uniprotId) {
+    return { geneFunction: null, bioProcessKeywordsOnly: [], urlAccession: null, bioProcessKeywords: [], uniprotUrl: null }
+  }
+
+  const cacheKey = `uniprot:${uniprotId}`
+  const cached = cacheGet(cacheKey)
+  if (cached !== undefined) return cached
+
+  try {
+    const [proteinRes, keywords] = await Promise.all([
+      axios.get(`https://www.ebi.ac.uk/proteins/api/proteins/${uniprotId}`, {
+        headers: { Accept: 'application/json' },
+        timeout: 10000,
+      }),
+      loadKeywords(),
+    ])
+
+    const data = proteinRes.data
+    let geneFunction = null
+    const bioProcessKeywords = []
+
+    if (data.comments && Array.isArray(data.comments)) {
+      const funcComment = data.comments.find((c) => c.type === 'FUNCTION')
+      if (funcComment) {
+        geneFunction = funcComment.text?.[0]?.value || null
+        if (geneFunction && geneFunction.length > 500) {
+          geneFunction = geneFunction.substring(0, 500) + '...'
+        }
+      }
+    }
+
+    // Extract biological process keywords
+    if (data.keywords && Array.isArray(data.keywords) && keywords) {
+      const entries = keywords.split('//')
+      for (const kw of data.keywords) {
+        const kwValue = kw.value
+        const entry = entries.find((e) => e.includes(`ID   ${kwValue}`))
+        if (entry) {
+          const isBioProcess = entry.split('\n').some((line) => line.startsWith('CA') && line.includes('Biological process'))
+          if (isBioProcess) {
+            bioProcessKeywords.push(kwValue)
+          }
+        }
+      }
+    }
+
+    const uniprotUrl = `https://www.uniprot.org/uniprotkb/${uniprotId}/entry`
+    const result = {
+      // Legacy keys (web app backward compat)
+      geneFunction,
+      bioProcessKeywordsOnly: bioProcessKeywords,
+      urlAccession: uniprotUrl,
+      // Enhanced keys
+      bioProcessKeywords,
+      uniprotUrl,
+    }
+    cacheSet(cacheKey, result)
+    return result
   } catch (error) {
-    console.error('Error fetching UniProt data:', error.message)
+    console.error(`UniProt fetch failed for ${uniprotId}: ${error.message}`)
+    const uniprotUrl = `https://www.uniprot.org/uniprotkb/${uniprotId}/entry`
+    return {
+      geneFunction: null,
+      bioProcessKeywordsOnly: [],
+      urlAccession: uniprotUrl,
+      bioProcessKeywords: [],
+      uniprotUrl,
+      error: error.message,
+    }
   }
 }
 

--- a/utils/rateLimiter.js
+++ b/utils/rateLimiter.js
@@ -1,0 +1,15 @@
+const RATE_DELAY_MS = 350 // Stay under 3 req/s without NCBI API key
+
+let lastRequestTime = 0
+
+async function rateLimitedGet(axios, url, options = {}) {
+  const now = Date.now()
+  const elapsed = now - lastRequestTime
+  if (elapsed < RATE_DELAY_MS) {
+    await new Promise((r) => setTimeout(r, RATE_DELAY_MS - elapsed))
+  }
+  lastRequestTime = Date.now()
+  return axios.get(url, { timeout: 15000, ...options })
+}
+
+module.exports = { rateLimitedGet }

--- a/utils/rateLimiter.js
+++ b/utils/rateLimiter.js
@@ -1,15 +1,78 @@
 const RATE_DELAY_MS = 350 // Stay under 3 req/s without NCBI API key
+const MAX_RETRIES = 2
+const BASE_BACKOFF_MS = 1000
 
-let lastRequestTime = 0
-
-async function rateLimitedGet(axios, url, options = {}) {
-  const now = Date.now()
-  const elapsed = now - lastRequestTime
-  if (elapsed < RATE_DELAY_MS) {
-    await new Promise((r) => setTimeout(r, RATE_DELAY_MS - elapsed))
+/**
+ * Queue-based rate limiter with retry logic.
+ *
+ * Uses a mutex (promise chain) to serialize concurrent requests,
+ * preventing race conditions on the timing check. All callers
+ * can fire requests concurrently — the queue ensures proper spacing.
+ *
+ * Retries on 429 (rate limited) and 5xx (server errors) with
+ * exponential backoff: 1s, 2s.
+ */
+class NcbiRateLimiter {
+  constructor(minDelayMs = RATE_DELAY_MS) {
+    this.minDelayMs = minDelayMs
+    this.lastRequestTime = 0
+    this.mutex = Promise.resolve()
   }
-  lastRequestTime = Date.now()
-  return axios.get(url, { timeout: 15000, ...options })
+
+  get(axios, url, options = {}) {
+    return new Promise((resolve, reject) => {
+      this.mutex = this.mutex.then(async () => {
+        try {
+          const result = await this._executeWithRetry(axios, url, options)
+          resolve(result)
+        } catch (error) {
+          reject(error)
+        }
+      })
+    })
+  }
+
+  async _executeWithRetry(axios, url, options) {
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        await this._waitForSlot()
+        this.lastRequestTime = Date.now()
+        return await axios.get(url, { timeout: 15000, ...options })
+      } catch (error) {
+        const isLastAttempt = attempt === MAX_RETRIES
+        if (isLastAttempt || !this._isRetryable(error)) {
+          throw error
+        }
+        const backoffMs = BASE_BACKOFF_MS * Math.pow(2, attempt)
+        await new Promise((r) => setTimeout(r, backoffMs))
+      }
+    }
+  }
+
+  async _waitForSlot() {
+    const now = Date.now()
+    const elapsed = now - this.lastRequestTime
+    if (elapsed < this.minDelayMs) {
+      await new Promise((r) => setTimeout(r, this.minDelayMs - elapsed))
+    }
+  }
+
+  _isRetryable(error) {
+    if (!error.response) return true // Network errors
+    const status = error.response.status
+    return status === 429 || status >= 500
+  }
 }
 
-module.exports = { rateLimitedGet }
+// Shared singleton — all NCBI calls (PubMed, ClinVar) go through this
+let ncbiLimiter = new NcbiRateLimiter()
+
+function rateLimitedGet(axios, url, options = {}) {
+  return ncbiLimiter.get(axios, url, options)
+}
+
+function resetLimiter() {
+  ncbiLimiter = new NcbiRateLimiter()
+}
+
+module.exports = { rateLimitedGet, NcbiRateLimiter, resetLimiter }


### PR DESCRIPTION
## Summary

This PR adds an **MCP (Model Context Protocol) server** to PubMatcher and upgrades the data-fetching layer to use **live APIs** instead of static files and web scraping.

All changes are made directly in `utils/` and `services/`, so both the existing web app and the new MCP server share the same code — no duplication.

### Data layer upgrades (backward-compatible)

| Source | Before | After |
|--------|--------|-------|
| **PubMed** | Cheerio web scraping | NCBI E-utilities API (abstracts, DOIs, authors, journals) |
| **ClinVar** | Static JSON (`BDD/clinvarCountsPerGene.json`) | Live NCBI ClinVar API + direct URLs |
| **gnomAD** | Static CSV (`BDD/constraints_v2.csv`, `v4.csv`) | GraphQL API (works for any gene, extra fields) |
| **ClinGen** | Static CSV (`BDD/gene_validity.csv`) | Live download from ClinGen endpoint |
| **OMIM** | No caching, no timeout | Caching + 30s timeout + error handling |
| **All sources** | Sequential execution, no caching, no rate limiting | Parallel via `Promise.allSettled`, 1h cache TTL, 350ms NCBI rate limiter with retry |

The web app's `getData(req)` function returns the **exact same keys** as before — the frontend doesn't need any changes.

### New shared infrastructure

- `utils/cache.js` — In-memory cache with configurable TTL
- `utils/rateLimiter.js` — Mutex-based queue with exponential backoff retry (429, 5xx)
- `utils/formatters.js` — Markdown formatters for MCP output (testable CJS module)
- `services/dataservice.js` — Exports both `analyzeGenes()` (flat, web app) and `analyzeGenesStructured()` (per-source, MCP) + `validateGene()` and `searchLiterature()`

### MCP server (`mcp/`)

A thin layer (~70 lines of tool definitions) that imports from `services/dataservice.js` and `utils/formatters.js`. Provides 3 tools:

- `analyze_genes` — Full 8-database analysis for 1-10 genes
- `validate_gene` — Quick HGNC + ClinGen check
- `search_literature` — PubMed search with phenotype refinement

Compatible with Claude Desktop, VS Code Copilot, Cursor, and any MCP client.

When a data source fails, the output explicitly warns the LLM (e.g. "ClinVar: unavailable (429 rate limited)") instead of silently showing zeros.

### Test suite (114 tests)

| Suite | Tests | Description |
|-------|-------|-------------|
| Unit tests | 97 | Fully mocked (axios/rateLimiter), ~10s |
| Integration tests | 17 | Real APIs, BRCA1+TP53, zero skips, ~17s |

Coverage: **99.64% lines**, 86.58% branches.

Run with:
```bash
npm test                  # unit tests
npm run test:integration  # real API tests
```

### Related issues

Closes #54 (PubMed API), closes #55 (ClinVar links), closes #56 (OMIM status), closes #40 (gnomAD constraints)

## Test plan

- [x] `npm test` — 97 unit tests pass
- [x] `npm run test:integration` — 17 integration tests pass against real APIs
- [x] MCP server starts and responds to `initialize`, `tools/list`, `tools/call`
- [x] `validate_gene BRCA1` returns correct gene info
- [x] `search_literature TP53 ["Li-Fraumeni"]` returns articles with abstracts
- [x] `analyze_genes ["BRCA1"] ["breast cancer"]` returns all 8 data sources
- [x] `validate_gene XYZFAKE` returns "not found" error
- [x] Web app backward compat: `getData(req)` returns all 25 expected keys